### PR TITLE
feat: Phase 1 completion - SqlServerCheckpointStore, ISnapshotPolicy, IDeadLetterStore, IProjectionStore, multi-partition Kafka

### DIFF
--- a/src/ZeroAlloc.EventSourcing.Aggregates/SnapshotCachingRepositoryDecorator.cs
+++ b/src/ZeroAlloc.EventSourcing.Aggregates/SnapshotCachingRepositoryDecorator.cs
@@ -58,8 +58,8 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
         if (strategy != SnapshotLoadingStrategy.IgnoreSnapshot && eventStore == null)
             throw new ArgumentNullException(nameof(eventStore), "Event store is required when strategy is not IgnoreSnapshot");
 
-        if (snapshotPolicy != null && snapshotPolicy != SnapshotPolicy.Never && extractState == null)
-            throw new ArgumentNullException(nameof(extractState), "extractState is required when a non-Never snapshotPolicy is provided");
+        if (snapshotPolicy != null && extractState == null)
+            throw new ArgumentNullException(nameof(extractState), "extractState is required when a snapshotPolicy is provided");
 
         _innerRepository = innerRepository;
         _snapshotStore = snapshotStore;
@@ -158,13 +158,13 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
     {
         var result = await _innerRepository.SaveAsync(aggregate, id, ct).ConfigureAwait(false);
 
-        if (result.IsSuccess && _snapshotPolicy != SnapshotPolicy.Never)
+        if (result.IsSuccess && _extractState != null)
         {
             var streamId = _streamIdFactory(id);
             var lastSnapshot = await _snapshotStore.ReadAsync(streamId, ct).ConfigureAwait(false);
             if (_snapshotPolicy.ShouldSnapshot(result.Value.NextExpectedVersion, lastSnapshot?.Position))
             {
-                var state = _extractState!(aggregate);
+                var state = _extractState(aggregate);
                 await _snapshotStore.WriteAsync(streamId, result.Value.NextExpectedVersion, state, ct).ConfigureAwait(false);
             }
         }

--- a/src/ZeroAlloc.EventSourcing.Aggregates/SnapshotCachingRepositoryDecorator.cs
+++ b/src/ZeroAlloc.EventSourcing.Aggregates/SnapshotCachingRepositoryDecorator.cs
@@ -37,7 +37,7 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
     /// <param name="restoreState">Callback to restore aggregate state from a snapshot before replaying events.</param>
     /// <param name="eventStore">Optional event store for reading events. Required if strategy is not IgnoreSnapshot.</param>
     /// <param name="streamIdFactory">Optional factory to map aggregate ID to stream ID. If not provided, standard convention is used.</param>
-    /// <param name="aggregateFactory">Optional factory to create fresh aggregate instances. Must be provided if snapshot optimization is used.</param>
+    /// <param name="aggregateFactory">Factory to create fresh aggregate instances. Required when <paramref name="strategy"/> is not <see cref="SnapshotLoadingStrategy.IgnoreSnapshot"/>.</param>
     /// <param name="snapshotPolicy">Optional policy controlling when snapshots are written on save. Defaults to <see cref="SnapshotPolicy.Never"/>.</param>
     /// <param name="extractState">Factory to extract state from an aggregate for snapshotting. Required when <paramref name="snapshotPolicy"/> is not Never.</param>
     public SnapshotCachingRepositoryDecorator(
@@ -67,7 +67,9 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
         _restoreState = restoreState;
         _eventStore = eventStore!;
         _streamIdFactory = streamIdFactory ?? (id => new StreamId($"aggregate-{id}"));
-        _aggregateFactory = aggregateFactory ?? throw new ArgumentNullException(nameof(aggregateFactory), "Aggregate factory is required for snapshot optimization");
+        if (strategy != SnapshotLoadingStrategy.IgnoreSnapshot && aggregateFactory == null)
+            throw new ArgumentNullException(nameof(aggregateFactory), "Aggregate factory is required when strategy is not IgnoreSnapshot");
+        _aggregateFactory = aggregateFactory!;
         _snapshotPolicy = snapshotPolicy ?? SnapshotPolicy.Never;
         _extractState = extractState;
     }

--- a/src/ZeroAlloc.EventSourcing.Aggregates/SnapshotCachingRepositoryDecorator.cs
+++ b/src/ZeroAlloc.EventSourcing.Aggregates/SnapshotCachingRepositoryDecorator.cs
@@ -25,6 +25,8 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
     private readonly Func<TId, StreamId> _streamIdFactory;
     private readonly IEventStore _eventStore;
     private readonly Func<TAggregate> _aggregateFactory;
+    private readonly ISnapshotPolicy _snapshotPolicy;
+    private readonly Func<TAggregate, TState>? _extractState;
 
     /// <summary>
     /// Initializes the decorator with snapshot loading configuration.
@@ -36,6 +38,8 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
     /// <param name="eventStore">Optional event store for reading events. Required if strategy is not IgnoreSnapshot.</param>
     /// <param name="streamIdFactory">Optional factory to map aggregate ID to stream ID. If not provided, standard convention is used.</param>
     /// <param name="aggregateFactory">Optional factory to create fresh aggregate instances. Must be provided if snapshot optimization is used.</param>
+    /// <param name="snapshotPolicy">Optional policy controlling when snapshots are written on save. Defaults to <see cref="SnapshotPolicy.Never"/>.</param>
+    /// <param name="extractState">Factory to extract state from an aggregate for snapshotting. Required when <paramref name="snapshotPolicy"/> is not Never.</param>
     public SnapshotCachingRepositoryDecorator(
         IAggregateRepository<TAggregate, TId> innerRepository,
         ISnapshotStore<TState> snapshotStore,
@@ -43,7 +47,9 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
         Action<TAggregate, TState, StreamPosition> restoreState,
         IEventStore? eventStore = null,
         Func<TId, StreamId>? streamIdFactory = null,
-        Func<TAggregate>? aggregateFactory = null)
+        Func<TAggregate>? aggregateFactory = null,
+        ISnapshotPolicy? snapshotPolicy = null,
+        Func<TAggregate, TState>? extractState = null)
     {
         ArgumentNullException.ThrowIfNull(innerRepository);
         ArgumentNullException.ThrowIfNull(snapshotStore);
@@ -52,6 +58,9 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
         if (strategy != SnapshotLoadingStrategy.IgnoreSnapshot && eventStore == null)
             throw new ArgumentNullException(nameof(eventStore), "Event store is required when strategy is not IgnoreSnapshot");
 
+        if (snapshotPolicy != null && snapshotPolicy != SnapshotPolicy.Never && extractState == null)
+            throw new ArgumentNullException(nameof(extractState), "extractState is required when a non-Never snapshotPolicy is provided");
+
         _innerRepository = innerRepository;
         _snapshotStore = snapshotStore;
         _strategy = strategy;
@@ -59,6 +68,8 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
         _eventStore = eventStore!;
         _streamIdFactory = streamIdFactory ?? (id => new StreamId($"aggregate-{id}"));
         _aggregateFactory = aggregateFactory ?? throw new ArgumentNullException(nameof(aggregateFactory), "Aggregate factory is required for snapshot optimization");
+        _snapshotPolicy = snapshotPolicy ?? SnapshotPolicy.Never;
+        _extractState = extractState;
     }
 
     /// <inheritdoc/>
@@ -143,7 +154,19 @@ public sealed class SnapshotCachingRepositoryDecorator<TAggregate, TId, TState> 
     /// <inheritdoc/>
     public async ValueTask<Result<AppendResult, StoreError>> SaveAsync(TAggregate aggregate, TId id, CancellationToken ct = default)
     {
-        // SaveAsync is not modified — always delegate to inner repository
-        return await _innerRepository.SaveAsync(aggregate, id, ct).ConfigureAwait(false);
+        var result = await _innerRepository.SaveAsync(aggregate, id, ct).ConfigureAwait(false);
+
+        if (result.IsSuccess && _snapshotPolicy != SnapshotPolicy.Never)
+        {
+            var streamId = _streamIdFactory(id);
+            var lastSnapshot = await _snapshotStore.ReadAsync(streamId, ct).ConfigureAwait(false);
+            if (_snapshotPolicy.ShouldSnapshot(result.Value.NextExpectedVersion, lastSnapshot?.Position))
+            {
+                var state = _extractState!(aggregate);
+                await _snapshotStore.WriteAsync(streamId, result.Value.NextExpectedVersion, state, ct).ConfigureAwait(false);
+            }
+        }
+
+        return result;
     }
 }

--- a/src/ZeroAlloc.EventSourcing.Generators/ZeroAlloc.EventSourcing.Generators.csproj
+++ b/src/ZeroAlloc.EventSourcing.Generators/ZeroAlloc.EventSourcing.Generators.csproj
@@ -9,8 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+    <!-- VersionOverride pins the generator to Roslyn 5.0.0 so the compiled DLL is loadable by the SDK
+         compiler (currently 5.0.0). Other projects continue to use the central 5.3.0 version.
+         Remove these overrides once the local SDK ships with Roslyn >= 5.3.0. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="3.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ZeroAlloc.EventSourcing.InMemory/InMemoryDeadLetterStore.cs
+++ b/src/ZeroAlloc.EventSourcing.InMemory/InMemoryDeadLetterStore.cs
@@ -1,0 +1,33 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace ZeroAlloc.EventSourcing.InMemory;
+
+/// <summary>Thread-safe in-memory dead-letter store. Not suitable for production use.</summary>
+public sealed class InMemoryDeadLetterStore : IDeadLetterStore
+{
+    private readonly ConcurrentQueue<DeadLetterEntry> _entries = new();
+
+    /// <inheritdoc/>
+    public ValueTask WriteAsync(string consumerId, EventEnvelope envelope, Exception exception, CancellationToken ct = default)
+    {
+        _entries.Enqueue(new DeadLetterEntry(
+            envelope,
+            consumerId,
+            exception.GetType().Name,
+            exception.Message,
+            DateTimeOffset.UtcNow));
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<DeadLetterEntry> ReadAllAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        foreach (var entry in _entries)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return entry;
+        }
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+}

--- a/src/ZeroAlloc.EventSourcing.InMemory/InMemoryDeadLetterStore.cs
+++ b/src/ZeroAlloc.EventSourcing.InMemory/InMemoryDeadLetterStore.cs
@@ -28,6 +28,5 @@ public sealed class InMemoryDeadLetterStore : IDeadLetterStore
             ct.ThrowIfCancellationRequested();
             yield return entry;
         }
-        await Task.CompletedTask.ConfigureAwait(false);
     }
 }

--- a/src/ZeroAlloc.EventSourcing.Kafka/KafkaConsumerOptions.cs
+++ b/src/ZeroAlloc.EventSourcing.Kafka/KafkaConsumerOptions.cs
@@ -26,11 +26,9 @@ public sealed class KafkaConsumerOptions
     public required string GroupId { get; set; }
 
     /// <summary>
-    /// Kafka partition to consume from.
-    /// Phase 6: Single partition support only.
-    /// Default: 0.
+    /// Kafka partitions to consume from. Defaults to partition 0 only.
     /// </summary>
-    public int Partition { get; set; } = 0;
+    public int[] Partitions { get; set; } = [0];
 
     /// <summary>
     /// Consumer identifier used in checkpoint store.

--- a/src/ZeroAlloc.EventSourcing.Kafka/KafkaConsumerOptions.cs
+++ b/src/ZeroAlloc.EventSourcing.Kafka/KafkaConsumerOptions.cs
@@ -54,6 +54,7 @@ public sealed class KafkaConsumerOptions
     /// </summary>
     /// <exception cref="ArgumentException">If required fields are null or whitespace.</exception>
     /// <exception cref="ArgumentOutOfRangeException">If PollTimeout is not positive.</exception>
+    /// <exception cref="InvalidOperationException">If Partitions is null or empty.</exception>
 #pragma warning disable MA0015
     public void Validate()
     {
@@ -65,6 +66,9 @@ public sealed class KafkaConsumerOptions
 
         if (string.IsNullOrWhiteSpace(GroupId))
             throw new ArgumentException("GroupId cannot be null or whitespace", nameof(GroupId));
+
+        if (Partitions == null || Partitions.Length == 0)
+            throw new InvalidOperationException("Partitions must contain at least one partition.");
 
         if (PollTimeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(PollTimeout), "PollTimeout must be positive");

--- a/src/ZeroAlloc.EventSourcing.Kafka/KafkaStreamConsumer.cs
+++ b/src/ZeroAlloc.EventSourcing.Kafka/KafkaStreamConsumer.cs
@@ -16,6 +16,7 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
     private readonly IConsumer<string, byte[]> _consumer;
     private readonly bool _ownsConsumer;  // true if we created the consumer internally
     private readonly ConcurrentDictionary<int, StreamPosition> _lastPositionPerPartition;
+    private readonly IDeadLetterStore? _deadLetterStore;
 
     /// <inheritdoc/>
     public string ConsumerId => _options.ConsumerId ?? _options.GroupId;
@@ -29,17 +30,20 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
     /// <param name="checkpointStore">Checkpoint store for position persistence.</param>
     /// <param name="serializer">Event serializer for deserializing message payloads.</param>
     /// <param name="registry">Event type registry for type resolution.</param>
-    /// <exception cref="ArgumentNullException">If any parameter is null.</exception>
+    /// <param name="deadLetterStore">Optional dead-letter store used when <see cref="StreamConsumerOptions.ErrorStrategy"/> is <see cref="ErrorHandlingStrategy.DeadLetter"/>.</param>
+    /// <exception cref="ArgumentNullException">If any required parameter is null.</exception>
     public KafkaStreamConsumer(
         KafkaConsumerOptions options,
         ICheckpointStore checkpointStore,
         IEventSerializer serializer,
-        IEventTypeRegistry registry)
+        IEventTypeRegistry registry,
+        IDeadLetterStore? deadLetterStore = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _checkpointStore = checkpointStore ?? throw new ArgumentNullException(nameof(checkpointStore));
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _deadLetterStore = deadLetterStore;
 
         // Validate options
         _options.Validate();
@@ -58,13 +62,15 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
         ICheckpointStore checkpointStore,
         IEventSerializer serializer,
         IEventTypeRegistry registry,
-        IConsumer<string, byte[]> consumer)
+        IConsumer<string, byte[]> consumer,
+        IDeadLetterStore? deadLetterStore = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _checkpointStore = checkpointStore ?? throw new ArgumentNullException(nameof(checkpointStore));
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         _registry = registry ?? throw new ArgumentNullException(nameof(registry));
         _consumer = consumer ?? throw new ArgumentNullException(nameof(consumer));
+        _deadLetterStore = deadLetterStore;
 
         // Validate options
         _options.Validate();
@@ -267,7 +273,7 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
                 var delay = _options.ConsumerOptions.RetryPolicy.GetDelay(attemptCount);
                 await Task.Delay(delay, ct).ConfigureAwait(false);
             }
-            catch (Exception) when (attemptCount >= _options.ConsumerOptions.MaxRetries)
+            catch (Exception ex) when (attemptCount >= _options.ConsumerOptions.MaxRetries)
             {
                 // Handle error based on strategy
                 switch (_options.ConsumerOptions.ErrorStrategy)
@@ -278,7 +284,12 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
                         // Skip this event and continue with the next
                         return;
                     case ErrorHandlingStrategy.DeadLetter:
-                        throw new NotSupportedException("Dead-letter strategy not yet implemented");
+                        if (_deadLetterStore == null)
+                            throw new InvalidOperationException(
+                                "ErrorHandlingStrategy.DeadLetter requires a dead-letter store. " +
+                                "Pass an IDeadLetterStore to the KafkaStreamConsumer constructor.");
+                        await _deadLetterStore.WriteAsync(ConsumerId, envelope, ex, ct).ConfigureAwait(false);
+                        return; // skip event, continue consuming
                     default:
                         throw;
                 }

--- a/src/ZeroAlloc.EventSourcing.Kafka/KafkaStreamConsumer.cs
+++ b/src/ZeroAlloc.EventSourcing.Kafka/KafkaStreamConsumer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Confluent.Kafka;
 
 namespace ZeroAlloc.EventSourcing.Kafka;
@@ -14,8 +15,7 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
     private readonly IEventTypeRegistry _registry;
     private readonly IConsumer<string, byte[]> _consumer;
     private readonly bool _ownsConsumer;  // true if we created the consumer internally
-    private StreamPosition? _currentPosition;
-    private int _currentPartition;
+    private readonly ConcurrentDictionary<int, StreamPosition> _lastPositionPerPartition;
 
     /// <inheritdoc/>
     public string ConsumerId => _options.ConsumerId ?? _options.GroupId;
@@ -47,6 +47,7 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
         // Build the Kafka consumer internally
         _consumer = BuildConsumer(_options);
         _ownsConsumer = true;
+        _lastPositionPerPartition = new ConcurrentDictionary<int, StreamPosition>();
     }
 
     /// <summary>
@@ -69,6 +70,7 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
         _options.Validate();
 
         _ownsConsumer = false;  // don't close/dispose injected consumer
+        _lastPositionPerPartition = new ConcurrentDictionary<int, StreamPosition>();
     }
 
     /// <inheritdoc/>
@@ -166,8 +168,7 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
             // Update position to the event we just processed
             var messagePosition = KafkaMessageMapper.ToStreamPosition(kafkaMessage.Offset);
             var messagePartition = kafkaMessage.Partition.Value;
-            _currentPosition = messagePosition;
-            _currentPartition = messagePartition;
+            _lastPositionPerPartition[messagePartition] = messagePosition;
             lastPositionPerPartition[messagePartition] = messagePosition;
 
             // Commit position after each event if configured
@@ -198,6 +199,9 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// For multi-partition consumers, returns the checkpoint position for the first configured partition only.
+    /// </remarks>
     public async Task<StreamPosition?> GetPositionAsync(CancellationToken ct = default)
     {
         return await _checkpointStore.ReadAsync(CheckpointKey(_options.Partitions[0]), ct).ConfigureAwait(false);
@@ -232,8 +236,10 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
     /// <inheritdoc/>
     public async Task CommitAsync(CancellationToken ct = default)
     {
-        if (_currentPosition.HasValue)
-            await _checkpointStore.WriteAsync(CheckpointKey(_currentPartition), _currentPosition.Value, ct).ConfigureAwait(false);
+        foreach (var (partition, position) in _lastPositionPerPartition)
+        {
+            await _checkpointStore.WriteAsync(CheckpointKey(partition), position, ct).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/src/ZeroAlloc.EventSourcing.Kafka/KafkaStreamConsumer.cs
+++ b/src/ZeroAlloc.EventSourcing.Kafka/KafkaStreamConsumer.cs
@@ -15,9 +15,12 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
     private readonly IConsumer<string, byte[]> _consumer;
     private readonly bool _ownsConsumer;  // true if we created the consumer internally
     private StreamPosition? _currentPosition;
+    private int _currentPartition;
 
     /// <inheritdoc/>
     public string ConsumerId => _options.ConsumerId ?? _options.GroupId;
+
+    private string CheckpointKey(int partition) => $"{ConsumerId}:p{partition}";
 
     /// <summary>
     /// Creates a new Kafka stream consumer that builds its own IConsumer internally.
@@ -78,15 +81,15 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
 
         try
         {
-            // Read the last checkpoint position, default to start
-            var position = await _checkpointStore.ReadAsync(ConsumerId, ct).ConfigureAwait(false) ?? StreamPosition.Start;
-            _currentPosition = position;
+            // Read the last checkpoint position per partition, default to start
+            var topicPartitions = new List<TopicPartitionOffset>(_options.Partitions.Length);
+            foreach (var partition in _options.Partitions)
+            {
+                var position = await _checkpointStore.ReadAsync(CheckpointKey(partition), ct).ConfigureAwait(false) ?? StreamPosition.Start;
+                topicPartitions.Add(new TopicPartitionOffset(_options.Topic, new Partition(partition), new Offset(position.Value)));
+            }
 
-            // Assign the partition and seek to start position
-            _consumer.Assign(new TopicPartitionOffset(
-                _options.Topic,
-                _options.Partition,
-                new Offset(position.Value)));
+            _consumer.Assign(topicPartitions);
 
             // Continuously process batches until no more events or cancellation requested
             await ProcessBatchesAsync(handler, ct).ConfigureAwait(false);
@@ -112,11 +115,14 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
             if (batch.Count == 0)
                 break;
 
-            await ProcessBatchAsync(handler, batch, ct).ConfigureAwait(false);
+            var lastPositionPerPartition = await ProcessBatchAsync(handler, batch, ct).ConfigureAwait(false);
 
             // Commit position after entire batch if configured
-            if (_options.ConsumerOptions.CommitStrategy == CommitStrategy.AfterBatch && _currentPosition.HasValue)
-                await _checkpointStore.WriteAsync(ConsumerId, _currentPosition.Value, ct).ConfigureAwait(false);
+            if (_options.ConsumerOptions.CommitStrategy == CommitStrategy.AfterBatch)
+            {
+                foreach (var (partition, position) in lastPositionPerPartition)
+                    await _checkpointStore.WriteAsync(CheckpointKey(partition), position, ct).ConfigureAwait(false);
+            }
         }
     }
 
@@ -140,12 +146,15 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
 
     /// <summary>
     /// Process a batch of Kafka messages.
+    /// Returns the last processed position per partition for AfterBatch checkpointing.
     /// </summary>
-    private async Task ProcessBatchAsync(
+    private async Task<Dictionary<int, StreamPosition>> ProcessBatchAsync(
         Func<EventEnvelope, CancellationToken, Task> handler,
         List<ConsumeResult<string, byte[]>> batch,
         CancellationToken ct)
     {
+        var lastPositionPerPartition = new Dictionary<int, StreamPosition>();
+
         foreach (var kafkaMessage in batch)
         {
             // Map Kafka message to EventEnvelope
@@ -156,12 +165,17 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
 
             // Update position to the event we just processed
             var messagePosition = KafkaMessageMapper.ToStreamPosition(kafkaMessage.Offset);
+            var messagePartition = kafkaMessage.Partition.Value;
             _currentPosition = messagePosition;
+            _currentPartition = messagePartition;
+            lastPositionPerPartition[messagePartition] = messagePosition;
 
             // Commit position after each event if configured
             if (_options.ConsumerOptions.CommitStrategy == CommitStrategy.AfterEvent)
-                await _checkpointStore.WriteAsync(ConsumerId, messagePosition, ct).ConfigureAwait(false);
+                await _checkpointStore.WriteAsync(CheckpointKey(messagePartition), messagePosition, ct).ConfigureAwait(false);
         }
+
+        return lastPositionPerPartition;
     }
 
     /// <summary>
@@ -186,30 +200,32 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
     /// <inheritdoc/>
     public async Task<StreamPosition?> GetPositionAsync(CancellationToken ct = default)
     {
-        return await _checkpointStore.ReadAsync(ConsumerId, ct).ConfigureAwait(false);
+        return await _checkpointStore.ReadAsync(CheckpointKey(_options.Partitions[0]), ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task ResetPositionAsync(StreamPosition position, CancellationToken ct = default)
     {
-        // Delete the checkpoint to reset
-        await _checkpointStore.DeleteAsync(ConsumerId, ct).ConfigureAwait(false);
-
-        // If position is not the start, write the new position
-        if (position.Value > 0)
-            await _checkpointStore.WriteAsync(ConsumerId, position, ct).ConfigureAwait(false);
-
-        // Seek to the new position in Kafka (only valid if partition is assigned)
-        try
+        // Delete and rewrite checkpoints for all partitions
+        foreach (var partition in _options.Partitions)
         {
-            _consumer.Seek(new TopicPartitionOffset(
-                _options.Topic,
-                _options.Partition,
-                new Offset(position.Value)));
-        }
-        catch (InvalidOperationException)
-        {
-            // Partition not assigned yet, will be assigned in next ConsumeAsync call
+            await _checkpointStore.DeleteAsync(CheckpointKey(partition), ct).ConfigureAwait(false);
+
+            if (position.Value > 0)
+                await _checkpointStore.WriteAsync(CheckpointKey(partition), position, ct).ConfigureAwait(false);
+
+            // Seek to the new position in Kafka (only valid if partition is assigned)
+            try
+            {
+                _consumer.Seek(new TopicPartitionOffset(
+                    _options.Topic,
+                    new Partition(partition),
+                    new Offset(position.Value)));
+            }
+            catch (InvalidOperationException)
+            {
+                // Partition not assigned yet, will be assigned in next ConsumeAsync call
+            }
         }
     }
 
@@ -217,7 +233,7 @@ public sealed class KafkaStreamConsumer : IStreamConsumer, IDisposable
     public async Task CommitAsync(CancellationToken ct = default)
     {
         if (_currentPosition.HasValue)
-            await _checkpointStore.WriteAsync(ConsumerId, _currentPosition.Value, ct).ConfigureAwait(false);
+            await _checkpointStore.WriteAsync(CheckpointKey(_currentPartition), _currentPosition.Value, ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/ZeroAlloc.EventSourcing.Sql/PostgreSqlDeadLetterStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Sql/PostgreSqlDeadLetterStore.cs
@@ -1,0 +1,119 @@
+using System.Runtime.CompilerServices;
+using Npgsql;
+using NpgsqlTypes;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Sql;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="IDeadLetterStore"/>.
+/// Stores permanently-failed events in a <c>dead_letters</c> table.
+/// </summary>
+public sealed class PostgreSqlDeadLetterStore : IDeadLetterStore
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly IEventSerializer _serializer;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PostgreSqlDeadLetterStore"/>.
+    /// </summary>
+    /// <param name="dataSource">The <see cref="NpgsqlDataSource"/> to use for connections.</param>
+    /// <param name="serializer">The serializer used to convert event payloads to bytes.</param>
+    /// <exception cref="ArgumentNullException">Thrown if either parameter is null.</exception>
+    public PostgreSqlDeadLetterStore(NpgsqlDataSource dataSource, IEventSerializer serializer)
+    {
+        _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+        _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+    }
+
+    /// <summary>
+    /// Creates the <c>dead_letters</c> table in PostgreSQL if it does not already exist.
+    /// This method is idempotent and safe to call multiple times.
+    /// </summary>
+    /// <param name="ct">A cancellation token.</param>
+    public async ValueTask EnsureSchemaAsync(CancellationToken ct = default)
+    {
+        #pragma warning disable MA0004
+        await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS dead_letters (
+                id               BIGSERIAL       PRIMARY KEY,
+                consumer_id      VARCHAR(256)    NOT NULL,
+                stream_id        VARCHAR(255)    NOT NULL,
+                position         BIGINT          NOT NULL,
+                event_type       VARCHAR(500)    NOT NULL,
+                payload          BYTEA           NOT NULL,
+                exception_type   VARCHAR(500)    NOT NULL,
+                exception_message TEXT           NOT NULL,
+                failed_at        TIMESTAMPTZ     NOT NULL
+            )
+            """;
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask WriteAsync(string consumerId, EventEnvelope envelope, Exception exception, CancellationToken ct = default)
+    {
+        var payload = _serializer.Serialize(envelope.Event).ToArray();
+        var failedAt = DateTimeOffset.UtcNow;
+
+        #pragma warning disable MA0004
+        await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO dead_letters
+                (consumer_id, stream_id, position, event_type, payload, exception_type, exception_message, failed_at)
+            VALUES
+                (@consumer_id, @stream_id, @position, @event_type, @payload, @exception_type, @exception_message, @failed_at)
+            """;
+
+        command.Parameters.AddWithValue("@consumer_id", consumerId);
+        command.Parameters.AddWithValue("@stream_id", envelope.StreamId.Value);
+        command.Parameters.AddWithValue("@position", envelope.Position.Value);
+        command.Parameters.AddWithValue("@event_type", envelope.Metadata.EventType);
+        command.Parameters.Add("@payload", NpgsqlDbType.Bytea).Value = payload;
+        command.Parameters.AddWithValue("@exception_type", exception.GetType().Name);
+        command.Parameters.AddWithValue("@exception_message", exception.Message);
+        command.Parameters.AddWithValue("@failed_at", failedAt);
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<DeadLetterEntry> ReadAllAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        #pragma warning disable MA0004
+        await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT consumer_id, stream_id, position, event_type, payload, exception_type, exception_message, failed_at
+            FROM dead_letters
+            ORDER BY id
+            """;
+
+        #pragma warning disable MA0004
+        await using var reader = await command.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var consumerId = reader.GetString(0);
+            var streamId = reader.GetString(1);
+            var position = reader.GetInt64(2);
+            var eventType = reader.GetString(3);
+            var payload = (byte[])reader.GetValue(4);
+            var exceptionType = reader.GetString(5);
+            var exceptionMessage = reader.GetString(6);
+            var failedAt = reader.GetFieldValue<DateTimeOffset>(7);
+
+            var metadata = new EventMetadata(Guid.NewGuid(), eventType, failedAt, null, null);
+            var envelope = new EventEnvelope(new StreamId(streamId), new StreamPosition(position), payload, metadata);
+
+            yield return new DeadLetterEntry(envelope, consumerId, exceptionType, exceptionMessage, failedAt);
+        }
+    }
+}

--- a/src/ZeroAlloc.EventSourcing.Sql/PostgreSqlProjectionStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Sql/PostgreSqlProjectionStore.cs
@@ -1,0 +1,101 @@
+using Npgsql;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Sql;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="IProjectionStore"/>.
+/// Stores projection state in a <c>projection_states</c> table using atomic upsert.
+/// </summary>
+public sealed class PostgreSqlProjectionStore : IProjectionStore
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private const string TableName = "projection_states";
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PostgreSqlProjectionStore"/>.
+    /// </summary>
+    /// <param name="dataSource">NpgsqlDataSource for connection pooling.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="dataSource"/> is null.</exception>
+    public PostgreSqlProjectionStore(NpgsqlDataSource dataSource)
+    {
+        ArgumentNullException.ThrowIfNull(dataSource);
+        _dataSource = dataSource;
+    }
+
+    /// <summary>
+    /// Creates the <c>projection_states</c> table if it does not already exist.
+    /// This method is idempotent and safe to call multiple times.
+    /// </summary>
+    /// <param name="ct">A cancellation token.</param>
+    public async ValueTask EnsureSchemaAsync(CancellationToken ct = default)
+    {
+        #pragma warning disable MA0004
+        await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+        using var command = connection.CreateCommand();
+        command.CommandText = $@"
+            CREATE TABLE IF NOT EXISTS {TableName} (
+                projection_key VARCHAR(256) PRIMARY KEY,
+                state TEXT NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL
+            );
+        ";
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask SaveAsync(string key, string state, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        #pragma warning disable MA0004
+        await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+        using var command = connection.CreateCommand();
+        command.CommandText = $@"
+            INSERT INTO {TableName} (projection_key, state, updated_at)
+            VALUES (@projection_key, @state, NOW())
+            ON CONFLICT (projection_key) DO UPDATE SET
+                state = EXCLUDED.state,
+                updated_at = EXCLUDED.updated_at;
+        ";
+        command.Parameters.AddWithValue("@projection_key", key);
+        command.Parameters.AddWithValue("@state", state);
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<string?> LoadAsync(string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        #pragma warning disable MA0004
+        await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+        using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT state FROM {TableName} WHERE projection_key = @projection_key";
+        command.Parameters.AddWithValue("@projection_key", key);
+
+        var result = await command.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return result != null && result != DBNull.Value
+            ? (string)result
+            : null;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask ClearAsync(string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        #pragma warning disable MA0004
+        await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+        using var command = connection.CreateCommand();
+        command.CommandText = $"DELETE FROM {TableName} WHERE projection_key = @projection_key";
+        command.Parameters.AddWithValue("@projection_key", key);
+
+        await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/ZeroAlloc.EventSourcing.Sql/PostgreSqlProjectionStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Sql/PostgreSqlProjectionStore.cs
@@ -48,6 +48,7 @@ public sealed class PostgreSqlProjectionStore : IProjectionStore
     public async ValueTask SaveAsync(string key, string state, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ValidateKey(key);
 
         #pragma warning disable MA0004
         await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
@@ -70,6 +71,7 @@ public sealed class PostgreSqlProjectionStore : IProjectionStore
     public async ValueTask<string?> LoadAsync(string key, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ValidateKey(key);
 
         #pragma warning disable MA0004
         await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
@@ -88,6 +90,7 @@ public sealed class PostgreSqlProjectionStore : IProjectionStore
     public async ValueTask ClearAsync(string key, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ValidateKey(key);
 
         #pragma warning disable MA0004
         await using var connection = await _dataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
@@ -97,5 +100,11 @@ public sealed class PostgreSqlProjectionStore : IProjectionStore
         command.Parameters.AddWithValue("@projection_key", key);
 
         await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private static void ValidateKey(string key)
+    {
+        if (key.Length > 256)
+            throw new ArgumentException("Projection key must not exceed 256 characters.", nameof(key));
     }
 }

--- a/src/ZeroAlloc.EventSourcing.Sql/SqlServerCheckpointStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Sql/SqlServerCheckpointStore.cs
@@ -1,0 +1,124 @@
+using Microsoft.Data.SqlClient;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Sql;
+
+/// <summary>
+/// SQL Server implementation of <see cref="ICheckpointStore"/>.
+/// Stores consumer positions in a <c>dbo.consumer_checkpoints</c> table using atomic MERGE upsert.
+/// </summary>
+public sealed class SqlServerCheckpointStore : ICheckpointStore
+{
+    private readonly string _connectionString;
+    private const string TableName = "dbo.consumer_checkpoints";
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="SqlServerCheckpointStore"/>.
+    /// </summary>
+    /// <param name="connectionString">A valid SQL Server connection string.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="connectionString"/> is null, empty, or whitespace-only.</exception>
+    public SqlServerCheckpointStore(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        _connectionString = connectionString;
+    }
+
+    /// <summary>
+    /// Creates the <c>dbo.consumer_checkpoints</c> table in SQL Server if it does not already exist.
+    /// This method is idempotent and safe to call multiple times.
+    /// </summary>
+    /// <param name="ct">A cancellation token.</param>
+    public async Task EnsureSchemaAsync(CancellationToken ct = default)
+    {
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = """
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.tables t
+                INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = 'dbo' AND t.name = 'consumer_checkpoints'
+            )
+            BEGIN
+                CREATE TABLE dbo.consumer_checkpoints (
+                    consumer_id VARCHAR(256) NOT NULL PRIMARY KEY,
+                    position    BIGINT       NOT NULL,
+                    updated_at  DATETIME2    NOT NULL
+                )
+            END
+            """;
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<StreamPosition?> ReadAsync(string consumerId, CancellationToken ct = default)
+    {
+        ValidateConsumerId(consumerId);
+
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = $"SELECT position FROM {TableName} WHERE consumer_id = @consumer_id";
+        cmd.Parameters.AddWithValue("@consumer_id", consumerId);
+
+        var result = await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return result != null && result != DBNull.Value
+            ? new StreamPosition((long)result)
+            : null;
+    }
+
+    /// <inheritdoc/>
+    public async Task WriteAsync(string consumerId, StreamPosition position, CancellationToken ct = default)
+    {
+        ValidateConsumerId(consumerId);
+
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = $"""
+            MERGE INTO {TableName} AS target
+            USING (SELECT @consumer_id AS consumer_id) AS source
+            ON target.consumer_id = source.consumer_id
+            WHEN MATCHED THEN UPDATE SET
+                position   = @position,
+                updated_at = @updated_at
+            WHEN NOT MATCHED THEN INSERT (consumer_id, position, updated_at)
+                VALUES (@consumer_id, @position, @updated_at);
+            """;
+        cmd.Parameters.AddWithValue("@consumer_id", consumerId);
+        cmd.Parameters.AddWithValue("@position", position.Value);
+        cmd.Parameters.AddWithValue("@updated_at", DateTime.UtcNow);
+
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteAsync(string consumerId, CancellationToken ct = default)
+    {
+        ValidateConsumerId(consumerId);
+
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = $"DELETE FROM {TableName} WHERE consumer_id = @consumer_id";
+        cmd.Parameters.AddWithValue("@consumer_id", consumerId);
+
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private static void ValidateConsumerId(string consumerId)
+    {
+        if (string.IsNullOrWhiteSpace(consumerId))
+            throw new ArgumentException("Consumer ID cannot be null or whitespace", nameof(consumerId));
+        if (consumerId.Length > 256)
+            throw new ArgumentException("Consumer ID cannot exceed 256 characters", nameof(consumerId));
+    }
+}

--- a/src/ZeroAlloc.EventSourcing.Sql/SqlServerCheckpointStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Sql/SqlServerCheckpointStore.cs
@@ -28,7 +28,7 @@ public sealed class SqlServerCheckpointStore : ICheckpointStore
     /// This method is idempotent and safe to call multiple times.
     /// </summary>
     /// <param name="ct">A cancellation token.</param>
-    public async Task EnsureSchemaAsync(CancellationToken ct = default)
+    public async ValueTask EnsureSchemaAsync(CancellationToken ct = default)
     {
         using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(ct).ConfigureAwait(false);

--- a/src/ZeroAlloc.EventSourcing.Sql/SqlServerDeadLetterStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Sql/SqlServerDeadLetterStore.cs
@@ -1,0 +1,130 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Data.SqlClient;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Sql;
+
+/// <summary>
+/// SQL Server implementation of <see cref="IDeadLetterStore"/>.
+/// Stores permanently-failed events in a <c>dbo.dead_letters</c> table.
+/// </summary>
+public sealed class SqlServerDeadLetterStore : IDeadLetterStore
+{
+    private readonly string _connectionString;
+    private readonly IEventSerializer _serializer;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="SqlServerDeadLetterStore"/>.
+    /// </summary>
+    /// <param name="connectionString">A valid SQL Server connection string.</param>
+    /// <param name="serializer">The serializer used to convert event payloads to bytes.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="connectionString"/> is null, empty, or whitespace-only.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="serializer"/> is null.</exception>
+    public SqlServerDeadLetterStore(string connectionString, IEventSerializer serializer)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        _connectionString = connectionString;
+        _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+    }
+
+    /// <summary>
+    /// Creates the <c>dbo.dead_letters</c> table in SQL Server if it does not already exist.
+    /// This method is idempotent and safe to call multiple times.
+    /// </summary>
+    /// <param name="ct">A cancellation token.</param>
+    public async ValueTask EnsureSchemaAsync(CancellationToken ct = default)
+    {
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = """
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.tables t
+                INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = 'dbo' AND t.name = 'dead_letters'
+            )
+            BEGIN
+                CREATE TABLE dbo.dead_letters (
+                    id                BIGINT IDENTITY(1,1) PRIMARY KEY,
+                    consumer_id       VARCHAR(256)         NOT NULL,
+                    stream_id         VARCHAR(255)         NOT NULL,
+                    position          BIGINT               NOT NULL,
+                    event_type        VARCHAR(500)         NOT NULL,
+                    payload           VARBINARY(MAX)       NOT NULL,
+                    exception_type    VARCHAR(500)         NOT NULL,
+                    exception_message NVARCHAR(MAX)        NOT NULL,
+                    failed_at         DATETIMEOFFSET       NOT NULL
+                )
+            END
+            """;
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask WriteAsync(string consumerId, EventEnvelope envelope, Exception exception, CancellationToken ct = default)
+    {
+        var payload = _serializer.Serialize(envelope.Event).ToArray();
+        var failedAt = DateTimeOffset.UtcNow;
+
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = """
+            INSERT INTO dbo.dead_letters
+                (consumer_id, stream_id, position, event_type, payload, exception_type, exception_message, failed_at)
+            VALUES
+                (@consumer_id, @stream_id, @position, @event_type, @payload, @exception_type, @exception_message, @failed_at)
+            """;
+
+        cmd.Parameters.AddWithValue("@consumer_id", consumerId);
+        cmd.Parameters.AddWithValue("@stream_id", envelope.StreamId.Value);
+        cmd.Parameters.AddWithValue("@position", envelope.Position.Value);
+        cmd.Parameters.AddWithValue("@event_type", envelope.Metadata.EventType);
+        cmd.Parameters.Add("@payload", System.Data.SqlDbType.VarBinary).Value = payload;
+        cmd.Parameters.AddWithValue("@exception_type", exception.GetType().Name);
+        cmd.Parameters.AddWithValue("@exception_message", exception.Message);
+        cmd.Parameters.AddWithValue("@failed_at", failedAt);
+
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<DeadLetterEntry> ReadAllAsync([EnumeratorCancellation] CancellationToken ct = default)
+    {
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = """
+            SELECT consumer_id, stream_id, position, event_type, payload, exception_type, exception_message, failed_at
+            FROM dbo.dead_letters
+            ORDER BY id
+            """;
+
+        #pragma warning disable MA0004
+        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        #pragma warning restore MA0004
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var consumerId = reader.GetString(0);
+            var streamId = reader.GetString(1);
+            var position = reader.GetInt64(2);
+            var eventType = reader.GetString(3);
+            var payload = (byte[])reader.GetValue(4);
+            var exceptionType = reader.GetString(5);
+            var exceptionMessage = reader.GetString(6);
+            var failedAt = reader.GetFieldValue<DateTimeOffset>(7);
+
+            var metadata = new EventMetadata(Guid.NewGuid(), eventType, failedAt, null, null);
+            var envelope = new EventEnvelope(new StreamId(streamId), new StreamPosition(position), payload, metadata);
+
+            yield return new DeadLetterEntry(envelope, consumerId, exceptionType, exceptionMessage, failedAt);
+        }
+    }
+}

--- a/src/ZeroAlloc.EventSourcing.Sql/SqlServerProjectionStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Sql/SqlServerProjectionStore.cs
@@ -56,6 +56,7 @@ public sealed class SqlServerProjectionStore : IProjectionStore
     public async ValueTask SaveAsync(string key, string state, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ValidateKey(key);
 
         using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(ct).ConfigureAwait(false);
@@ -83,6 +84,7 @@ public sealed class SqlServerProjectionStore : IProjectionStore
     public async ValueTask<string?> LoadAsync(string key, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ValidateKey(key);
 
         using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(ct).ConfigureAwait(false);
@@ -102,6 +104,7 @@ public sealed class SqlServerProjectionStore : IProjectionStore
     public async ValueTask ClearAsync(string key, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ValidateKey(key);
 
         using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(ct).ConfigureAwait(false);
@@ -112,5 +115,11 @@ public sealed class SqlServerProjectionStore : IProjectionStore
         cmd.Parameters.AddWithValue("@projection_key", key);
 
         await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    private static void ValidateKey(string key)
+    {
+        if (key.Length > 256)
+            throw new ArgumentException("Projection key must not exceed 256 characters.", nameof(key));
     }
 }

--- a/src/ZeroAlloc.EventSourcing.Sql/SqlServerProjectionStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Sql/SqlServerProjectionStore.cs
@@ -1,0 +1,116 @@
+using Microsoft.Data.SqlClient;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Sql;
+
+/// <summary>
+/// SQL Server implementation of <see cref="IProjectionStore"/>.
+/// Stores projection state in a <c>dbo.projection_states</c> table using atomic MERGE upsert.
+/// </summary>
+public sealed class SqlServerProjectionStore : IProjectionStore
+{
+    private readonly string _connectionString;
+    private const string TableName = "dbo.projection_states";
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="SqlServerProjectionStore"/>.
+    /// </summary>
+    /// <param name="connectionString">A valid SQL Server connection string.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="connectionString"/> is null, empty, or whitespace-only.</exception>
+    public SqlServerProjectionStore(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        _connectionString = connectionString;
+    }
+
+    /// <summary>
+    /// Creates the <c>dbo.projection_states</c> table in SQL Server if it does not already exist.
+    /// This method is idempotent and safe to call multiple times.
+    /// </summary>
+    /// <param name="ct">A cancellation token.</param>
+    public async ValueTask EnsureSchemaAsync(CancellationToken ct = default)
+    {
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = """
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.tables t
+                INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = 'dbo' AND t.name = 'projection_states'
+            )
+            BEGIN
+                CREATE TABLE dbo.projection_states (
+                    projection_key VARCHAR(256)   NOT NULL PRIMARY KEY,
+                    state          NVARCHAR(MAX)  NOT NULL,
+                    updated_at     DATETIME2      NOT NULL
+                )
+            END
+            """;
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask SaveAsync(string key, string state, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = $"""
+            MERGE INTO {TableName} AS target
+            USING (SELECT @projection_key AS projection_key) AS source
+            ON target.projection_key = source.projection_key
+            WHEN MATCHED THEN UPDATE SET
+                state      = @state,
+                updated_at = @updated_at
+            WHEN NOT MATCHED THEN INSERT (projection_key, state, updated_at)
+                VALUES (@projection_key, @state, @updated_at);
+            """;
+        cmd.Parameters.AddWithValue("@projection_key", key);
+        cmd.Parameters.AddWithValue("@state", state);
+        cmd.Parameters.AddWithValue("@updated_at", DateTime.UtcNow);
+
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<string?> LoadAsync(string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = $"SELECT state FROM {TableName} WHERE projection_key = @projection_key";
+        cmd.Parameters.AddWithValue("@projection_key", key);
+
+        var result = await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return result != null && result != DBNull.Value
+            ? (string)result
+            : null;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask ClearAsync(string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        #pragma warning disable MA0004
+        using var cmd = conn.CreateCommand();
+        #pragma warning restore MA0004
+        cmd.CommandText = $"DELETE FROM {TableName} WHERE projection_key = @projection_key";
+        cmd.Parameters.AddWithValue("@projection_key", key);
+
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/ZeroAlloc.EventSourcing/DeadLetterEntry.cs
+++ b/src/ZeroAlloc.EventSourcing/DeadLetterEntry.cs
@@ -1,0 +1,9 @@
+namespace ZeroAlloc.EventSourcing;
+
+/// <summary>Represents a single event that failed processing after all retries were exhausted.</summary>
+public sealed record DeadLetterEntry(
+    EventEnvelope Envelope,
+    string ConsumerId,
+    string ExceptionType,
+    string ExceptionMessage,
+    DateTimeOffset FailedAt);

--- a/src/ZeroAlloc.EventSourcing/ErrorHandlingStrategy.cs
+++ b/src/ZeroAlloc.EventSourcing/ErrorHandlingStrategy.cs
@@ -11,6 +11,6 @@ public enum ErrorHandlingStrategy
     /// <summary>Skip failing event, continue processing with next event</summary>
     Skip = 1,
 
-    /// <summary>Route to dead-letter store for later analysis (future feature)</summary>
+    /// <summary>Route failed events to a dead-letter store for later analysis or manual replay.</summary>
     DeadLetter = 2,
 }

--- a/src/ZeroAlloc.EventSourcing/IDeadLetterStore.cs
+++ b/src/ZeroAlloc.EventSourcing/IDeadLetterStore.cs
@@ -1,0 +1,13 @@
+namespace ZeroAlloc.EventSourcing;
+
+/// <summary>
+/// Stores events that permanently failed processing after all retries are exhausted.
+/// </summary>
+public interface IDeadLetterStore
+{
+    /// <summary>Persist a failed event with its exception details.</summary>
+    ValueTask WriteAsync(string consumerId, EventEnvelope envelope, Exception exception, CancellationToken ct = default);
+
+    /// <summary>Read all dead-letter entries. For monitoring and manual replay.</summary>
+    IAsyncEnumerable<DeadLetterEntry> ReadAllAsync(CancellationToken ct = default);
+}

--- a/src/ZeroAlloc.EventSourcing/ISnapshotPolicy.cs
+++ b/src/ZeroAlloc.EventSourcing/ISnapshotPolicy.cs
@@ -1,0 +1,14 @@
+namespace ZeroAlloc.EventSourcing;
+
+/// <summary>
+/// Controls when a snapshot should be written for an aggregate stream.
+/// </summary>
+public interface ISnapshotPolicy
+{
+    /// <summary>
+    /// Returns true if a snapshot should be written at <paramref name="currentPosition"/>.
+    /// </summary>
+    /// <param name="currentPosition">The aggregate's current stream position after saving.</param>
+    /// <param name="lastSnapshotPosition">The position of the last written snapshot, or null if none.</param>
+    bool ShouldSnapshot(StreamPosition currentPosition, StreamPosition? lastSnapshotPosition);
+}

--- a/src/ZeroAlloc.EventSourcing/SnapshotPolicy.cs
+++ b/src/ZeroAlloc.EventSourcing/SnapshotPolicy.cs
@@ -1,0 +1,45 @@
+namespace ZeroAlloc.EventSourcing;
+
+/// <summary>Factory for built-in <see cref="ISnapshotPolicy"/> implementations.</summary>
+public static class SnapshotPolicy
+{
+    /// <summary>Write a snapshot every time an aggregate is saved.</summary>
+    public static ISnapshotPolicy Always { get; } = new AlwaysPolicy();
+
+    /// <summary>Never write automatic snapshots.</summary>
+    public static ISnapshotPolicy Never { get; } = new NeverPolicy();
+
+    /// <summary>
+    /// Write a snapshot when at least <paramref name="n"/> events have been appended since the
+    /// last snapshot (or since stream start if none exists).
+    /// </summary>
+    /// <param name="n">Minimum event interval. Must be ≥ 1.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="n"/> is less than 1.</exception>
+    public static ISnapshotPolicy EveryNEvents(int n)
+    {
+        if (n < 1) throw new ArgumentOutOfRangeException(nameof(n), "Snapshot interval must be at least 1");
+        return new EveryNEventsPolicy(n);
+    }
+
+    private sealed class AlwaysPolicy : ISnapshotPolicy
+    {
+        public bool ShouldSnapshot(StreamPosition currentPosition, StreamPosition? lastSnapshotPosition) => true;
+    }
+
+    private sealed class NeverPolicy : ISnapshotPolicy
+    {
+        public bool ShouldSnapshot(StreamPosition currentPosition, StreamPosition? lastSnapshotPosition) => false;
+    }
+
+    private sealed class EveryNEventsPolicy : ISnapshotPolicy
+    {
+        private readonly int _n;
+        public EveryNEventsPolicy(int n) => _n = n;
+
+        public bool ShouldSnapshot(StreamPosition currentPosition, StreamPosition? lastSnapshotPosition)
+        {
+            var baseline = lastSnapshotPosition?.Value ?? 0L;
+            return (currentPosition.Value - baseline) >= _n;
+        }
+    }
+}

--- a/src/ZeroAlloc.EventSourcing/StreamConsumer.cs
+++ b/src/ZeroAlloc.EventSourcing/StreamConsumer.cs
@@ -9,6 +9,7 @@ public sealed class StreamConsumer : IStreamConsumer
     private readonly ICheckpointStore _checkpointStore;
     private readonly StreamConsumerOptions _options;
     private readonly StreamId _streamId;
+    private readonly IDeadLetterStore? _deadLetterStore;
     private StreamPosition? _currentPosition;
 
     /// <inheritdoc/>
@@ -20,12 +21,14 @@ public sealed class StreamConsumer : IStreamConsumer
     /// <param name="consumerId">Unique identifier for this consumer.</param>
     /// <param name="options">Configuration options (uses defaults if null).</param>
     /// <param name="streamId">The stream to consume from (defaults to "*" for global stream).</param>
+    /// <param name="deadLetterStore">Optional dead-letter store used when <see cref="StreamConsumerOptions.ErrorStrategy"/> is <see cref="ErrorHandlingStrategy.DeadLetter"/>.</param>
     public StreamConsumer(
         IEventStore eventStore,
         ICheckpointStore checkpointStore,
         string consumerId,
         StreamConsumerOptions? options = null,
-        StreamId? streamId = null)
+        StreamId? streamId = null,
+        IDeadLetterStore? deadLetterStore = null)
     {
         if (string.IsNullOrWhiteSpace(consumerId))
             throw new ArgumentException("Consumer ID cannot be null or whitespace", nameof(consumerId));
@@ -34,6 +37,7 @@ public sealed class StreamConsumer : IStreamConsumer
         _checkpointStore = checkpointStore ?? throw new ArgumentNullException(nameof(checkpointStore));
         _options = options ?? new StreamConsumerOptions();
         _streamId = streamId ?? new StreamId("*");
+        _deadLetterStore = deadLetterStore;
         ConsumerId = consumerId;
     }
 
@@ -123,7 +127,7 @@ public sealed class StreamConsumer : IStreamConsumer
                 var delay = _options.RetryPolicy.GetDelay(attemptCount);
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception) when (attemptCount >= _options.MaxRetries)
+            catch (Exception ex) when (attemptCount >= _options.MaxRetries)
             {
                 // Retries exhausted
                 switch (_options.ErrorStrategy)
@@ -134,7 +138,12 @@ public sealed class StreamConsumer : IStreamConsumer
                         // Log and continue silently
                         return;
                     case ErrorHandlingStrategy.DeadLetter:
-                        throw new NotSupportedException("Dead-letter strategy not yet implemented");
+                        if (_deadLetterStore == null)
+                            throw new InvalidOperationException(
+                                "ErrorHandlingStrategy.DeadLetter requires a dead-letter store. " +
+                                "Pass an IDeadLetterStore to the StreamConsumer constructor.");
+                        await _deadLetterStore.WriteAsync(ConsumerId, envelope, ex, cancellationToken).ConfigureAwait(false);
+                        return; // skip this event and continue consuming
                     default:
                         throw;
                 }

--- a/tests/ZeroAlloc.EventSourcing.InMemory.Tests/InMemoryDeadLetterStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.InMemory.Tests/InMemoryDeadLetterStoreTests.cs
@@ -1,0 +1,10 @@
+using ZeroAlloc.EventSourcing;
+using ZeroAlloc.EventSourcing.InMemory;
+using ZeroAlloc.EventSourcing.Tests;
+
+namespace ZeroAlloc.EventSourcing.InMemory.Tests;
+
+public sealed class InMemoryDeadLetterStoreTests : DeadLetterStoreContractTests
+{
+    protected override IDeadLetterStore CreateStore() => new InMemoryDeadLetterStore();
+}

--- a/tests/ZeroAlloc.EventSourcing.InMemory.Tests/InMemoryProjectionStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.InMemory.Tests/InMemoryProjectionStoreTests.cs
@@ -1,14 +1,19 @@
 using FluentAssertions;
+using ZeroAlloc.EventSourcing;
 using ZeroAlloc.EventSourcing.InMemory;
+using ZeroAlloc.EventSourcing.Tests;
 
 namespace ZeroAlloc.EventSourcing.InMemory.Tests;
 
 /// <summary>
 /// Unit tests for <see cref="InMemoryProjectionStore"/>. Verifies that the in-memory store
 /// correctly saves, loads, and clears projection state.
+/// Also inherits all contract tests from <see cref="ProjectionStoreContractTests"/>.
 /// </summary>
-public class InMemoryProjectionStoreTests
+public class InMemoryProjectionStoreTests : ProjectionStoreContractTests
 {
+    protected override IProjectionStore CreateStore() => new InMemoryProjectionStore();
+
     [Fact]
     public async Task SaveThenLoad_ReturnsStoredState()
     {

--- a/tests/ZeroAlloc.EventSourcing.Kafka.Tests/KafkaConsumerOptionsTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Kafka.Tests/KafkaConsumerOptionsTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+
+namespace ZeroAlloc.EventSourcing.Kafka.Tests;
+
+public class KafkaConsumerOptionsTests
+{
+    [Fact]
+    public void Partitions_DefaultsToSinglePartitionZero()
+    {
+        // Arrange & Act
+        var options = new KafkaConsumerOptions
+        {
+            BootstrapServers = "localhost:9092",
+            Topic = "test-topic",
+            GroupId = "test-group"
+        };
+
+        // Assert
+        options.Partitions.Should().Equal([0]);
+    }
+
+    [Fact]
+    public void Partitions_AcceptsMultiplePartitions()
+    {
+        // Arrange & Act
+        var options = new KafkaConsumerOptions
+        {
+            BootstrapServers = "localhost:9092",
+            Topic = "test-topic",
+            GroupId = "test-group",
+            Partitions = [0, 1, 2]
+        };
+
+        // Assert
+        options.Partitions.Should().Equal([0, 1, 2]);
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Kafka.Tests/KafkaConsumerOptionsTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Kafka.Tests/KafkaConsumerOptionsTests.cs
@@ -34,4 +34,19 @@ public class KafkaConsumerOptionsTests
         // Assert
         options.Partitions.Should().Equal([0, 1, 2]);
     }
+
+    [Fact]
+    public void KafkaConsumerOptions_EmptyPartitions_ThrowsOnValidate()
+    {
+        var opts = new KafkaConsumerOptions
+        {
+            BootstrapServers = "localhost:9092",
+            Topic = "events",
+            GroupId = "g1",
+            Partitions = []
+        };
+        var act = () => opts.Validate();
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*Partitions*");
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Kafka.Tests/KafkaStreamConsumerIntegrationTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Kafka.Tests/KafkaStreamConsumerIntegrationTests.cs
@@ -38,7 +38,7 @@ public class KafkaStreamConsumerIntegrationTests : IAsyncLifetime
             BootstrapServers = _bootstrapServers,
             Topic = topic,
             GroupId = "test-group-1",
-            Partition = TestPartition,
+            Partitions = [TestPartition],
             ConsumerOptions = new()
             {
                 BatchSize = 100,
@@ -83,7 +83,7 @@ public class KafkaStreamConsumerIntegrationTests : IAsyncLifetime
             BootstrapServers = _bootstrapServers,
             Topic = topic,
             GroupId = "test-group-2",
-            Partition = TestPartition,
+            Partitions = [TestPartition],
             ConsumerOptions = new()
             {
                 BatchSize = 100,
@@ -144,7 +144,7 @@ public class KafkaStreamConsumerIntegrationTests : IAsyncLifetime
             BootstrapServers = _bootstrapServers,
             Topic = topic,
             GroupId = "test-group-3",
-            Partition = TestPartition,
+            Partitions = [TestPartition],
             ConsumerOptions = new()
             {
                 BatchSize = 100,
@@ -198,7 +198,7 @@ public class KafkaStreamConsumerIntegrationTests : IAsyncLifetime
             BootstrapServers = _bootstrapServers,
             Topic = topic,
             GroupId = "test-group-4",
-            Partition = TestPartition,
+            Partitions = [TestPartition],
             ConsumerOptions = new()
             {
                 BatchSize = 100,
@@ -241,7 +241,7 @@ public class KafkaStreamConsumerIntegrationTests : IAsyncLifetime
             BootstrapServers = _bootstrapServers,
             Topic = topic,
             GroupId = "test-group-5a",
-            Partition = TestPartition,
+            Partitions = [TestPartition],
             ConsumerOptions = new()
             {
                 BatchSize = 100,
@@ -256,7 +256,7 @@ public class KafkaStreamConsumerIntegrationTests : IAsyncLifetime
             BootstrapServers = _bootstrapServers,
             Topic = topic,
             GroupId = "test-group-5b",
-            Partition = TestPartition,
+            Partitions = [TestPartition],
             ConsumerOptions = new()
             {
                 BatchSize = 100,

--- a/tests/ZeroAlloc.EventSourcing.Kafka.Tests/KafkaStreamConsumerTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Kafka.Tests/KafkaStreamConsumerTests.cs
@@ -18,7 +18,7 @@ public class KafkaStreamConsumerTests
             BootstrapServers = "localhost:9092",
             Topic = TestTopic,
             GroupId = TestGroupId,
-            Partition = TestPartition,
+            Partitions = [TestPartition],
             ConsumerId = consumerId,
             ConsumerOptions = new()
             {

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/PostgreSqlCollection.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/PostgreSqlCollection.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace ZeroAlloc.EventSourcing.Sql.Tests;
+
+[CollectionDefinition("PostgreSQL", DisableParallelization = true)]
+public sealed class PostgreSqlCollection { }

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/PostgreSqlDeadLetterStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/PostgreSqlDeadLetterStoreTests.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using Npgsql;
+using Testcontainers.PostgreSql;
+using ZeroAlloc.EventSourcing;
+using ZeroAlloc.EventSourcing.Sql;
+using ZeroAlloc.EventSourcing.Tests;
+
+namespace ZeroAlloc.EventSourcing.Sql.Tests;
+
+[Collection("PostgreSQL")]
+public sealed class PostgreSqlDeadLetterStoreTests : DeadLetterStoreContractTests, IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:16-alpine").Build();
+    private NpgsqlDataSource _dataSource = null!;
+    private PostgreSqlDeadLetterStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync().ConfigureAwait(false);
+        _dataSource = NpgsqlDataSource.Create(_container.GetConnectionString());
+        _store = new PostgreSqlDeadLetterStore(_dataSource, new JsonEventSerializer());
+        await _store.EnsureSchemaAsync().ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dataSource.DisposeAsync().ConfigureAwait(false);
+        await _container.StopAsync().ConfigureAwait(false);
+    }
+
+    protected override IDeadLetterStore CreateStore() => _store;
+
+    private sealed class JsonEventSerializer : IEventSerializer
+    {
+        public ReadOnlyMemory<byte> Serialize<TEvent>(TEvent @event) where TEvent : notnull
+            => System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(@event));
+
+        public object Deserialize(ReadOnlyMemory<byte> data, Type targetType)
+            => JsonSerializer.Deserialize(System.Text.Encoding.UTF8.GetString(data.Span), targetType)
+               ?? throw new InvalidOperationException("Deserialization returned null");
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/PostgreSqlProjectionStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/PostgreSqlProjectionStoreTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using Npgsql;
+using Testcontainers.PostgreSql;
+using Xunit;
+using ZeroAlloc.EventSourcing;
+using ZeroAlloc.EventSourcing.Sql;
+using ZeroAlloc.EventSourcing.Tests;
+
+namespace ZeroAlloc.EventSourcing.Sql.Tests;
+
+[Collection("PostgreSQL")]
+public sealed class PostgreSqlProjectionStoreTests : ProjectionStoreContractTests, IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:16-alpine").Build();
+    private NpgsqlDataSource _dataSource = null!;
+    private PostgreSqlProjectionStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        _dataSource = NpgsqlDataSource.Create(_container.GetConnectionString());
+        _store = new PostgreSqlProjectionStore(_dataSource);
+        await _store.EnsureSchemaAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dataSource.DisposeAsync();
+        await _container.StopAsync();
+    }
+
+    protected override IProjectionStore CreateStore() => _store;
+
+    [Fact]
+    public async Task EnsureSchemaAsync_IsIdempotent()
+    {
+        await _store.EnsureSchemaAsync(); // second call must not throw
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/PostgreSqlSnapshotStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/PostgreSqlSnapshotStoreTests.cs
@@ -1,16 +1,22 @@
+using System.Text.Json;
 using FluentAssertions;
 using Npgsql;
+using Testcontainers.PostgreSql;
 using ZeroAlloc.EventSourcing;
 using ZeroAlloc.EventSourcing.Sql;
 
 namespace ZeroAlloc.EventSourcing.Sql.Tests;
 
 /// <summary>
-/// Contract tests for <see cref="PostgreSqlSnapshotStore{TState}"/>.
+/// Contract tests for <see cref="PostgreSqlSnapshotStore{TState}"/> against a real PostgreSQL database.
 /// Inherits all contract tests from <see cref="SnapshotStoreContractTests{TStore}"/>.
 /// </summary>
-public class PostgreSqlSnapshotStoreTests : SnapshotStoreContractTests<PostgreSqlSnapshotStore<SnapshotTestState>>
+[Collection("PostgreSQL")]
+public sealed class PostgreSqlSnapshotStoreTests : SnapshotStoreContractTests<PostgreSqlSnapshotStore<SnapshotTestState>>
 {
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:16-alpine").Build();
+    private NpgsqlDataSource _dataSource = null!;
+
     /// <summary>Test that constructor rejects null dataSource.</summary>
     [Fact]
     public void Constructor_NullDataSource_ThrowsArgumentNullException()
@@ -19,39 +25,30 @@ public class PostgreSqlSnapshotStoreTests : SnapshotStoreContractTests<PostgreSq
             .Should().Throw<ArgumentNullException>();
     }
 
-    /// <summary>Test that constructor accepts valid dataSource.</summary>
-    [Fact]
-    public void Constructor_ValidDataSource_Succeeds()
-    {
-        var dataSource = NpgsqlDataSource.Create("Host=localhost;Database=test;Username=postgres;Password=postgres");
-
-        FluentActions.Invoking(() => new PostgreSqlSnapshotStore<SnapshotTestState>(dataSource))
-            .Should().NotThrow();
-    }
-
     /// <inheritdoc/>
     protected override async Task<PostgreSqlSnapshotStore<SnapshotTestState>> CreateStoreAsync()
     {
-        var dataSource = NpgsqlDataSource.Create("Host=localhost;Database=test;Username=postgres;Password=postgres");
-        var store = new PostgreSqlSnapshotStore<SnapshotTestState>(dataSource);
-        // EnsureSchemaAsync is called to initialize the database schema
-        // In real tests with a database, this would create the table
-        // For unit tests with dummy connection strings, this is a no-op
-        try
-        {
-            await store.EnsureSchemaAsync();
-        }
-        catch
-        {
-            // Ignore connection errors for unit tests with dummy connection strings
-        }
+        await _container.StartAsync();
+        _dataSource = NpgsqlDataSource.Create(_container.GetConnectionString());
+        var store = new PostgreSqlSnapshotStore<SnapshotTestState>(_dataSource, new JsonEventSerializer());
+        await store.EnsureSchemaAsync();
         return store;
     }
 
     /// <inheritdoc/>
     public override async Task DisposeAsync()
     {
-        // No resources to dispose for unit tests with dummy connection strings
-        await Task.CompletedTask;
+        await _dataSource.DisposeAsync();
+        await _container.StopAsync();
+    }
+
+    private sealed class JsonEventSerializer : IEventSerializer
+    {
+        public ReadOnlyMemory<byte> Serialize<TEvent>(TEvent @event) where TEvent : notnull
+            => System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(@event));
+
+        public object Deserialize(ReadOnlyMemory<byte> data, Type targetType)
+            => JsonSerializer.Deserialize(System.Text.Encoding.UTF8.GetString(data.Span), targetType)
+               ?? throw new InvalidOperationException("Deserialization returned null");
     }
 }

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerCheckpointStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerCheckpointStoreTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Testcontainers.MsSql;
+using Xunit;
+using ZeroAlloc.EventSourcing;
+using ZeroAlloc.EventSourcing.Sql;
+using ZeroAlloc.EventSourcing.Tests;
+
+namespace ZeroAlloc.EventSourcing.Sql.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="SqlServerCheckpointStore"/> using a real SQL Server instance via Testcontainers.
+/// Inherits all contract tests from <see cref="CheckpointStoreContractTests"/>.
+/// </summary>
+[Collection("SqlServer")]
+public sealed class SqlServerCheckpointStoreTests : CheckpointStoreContractTests, IAsyncLifetime
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest").Build();
+    private SqlServerCheckpointStore _store = null!;
+
+    /// <inheritdoc/>
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        _store = new SqlServerCheckpointStore(_container.GetConnectionString());
+        await _store.EnsureSchemaAsync();
+    }
+
+    /// <inheritdoc/>
+    public async Task DisposeAsync()
+    {
+        await _container.StopAsync();
+    }
+
+    /// <inheritdoc/>
+    protected override ICheckpointStore CreateStore() => _store;
+
+    /// <summary>
+    /// Verifies that calling <see cref="SqlServerCheckpointStore.EnsureSchemaAsync"/> multiple times does not throw.
+    /// </summary>
+    [Fact]
+    public async Task EnsureSchemaAsync_IsIdempotent()
+    {
+        var exception = await Record.ExceptionAsync(async () =>
+        {
+            await _store.EnsureSchemaAsync();
+            await _store.EnsureSchemaAsync();
+        });
+
+        exception.Should().BeNull();
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerCollection.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerCollection.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace ZeroAlloc.EventSourcing.Sql.Tests;
+
+[CollectionDefinition("SqlServer", DisableParallelization = true)]
+public sealed class SqlServerCollection { }

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerDeadLetterStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerDeadLetterStoreTests.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Testcontainers.MsSql;
+using ZeroAlloc.EventSourcing;
+using ZeroAlloc.EventSourcing.Sql;
+using ZeroAlloc.EventSourcing.Tests;
+
+namespace ZeroAlloc.EventSourcing.Sql.Tests;
+
+[Collection("SqlServer")]
+public sealed class SqlServerDeadLetterStoreTests : DeadLetterStoreContractTests, IAsyncLifetime
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest").Build();
+    private SqlServerDeadLetterStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync().ConfigureAwait(false);
+        _store = new SqlServerDeadLetterStore(_container.GetConnectionString(), new JsonEventSerializer());
+        await _store.EnsureSchemaAsync().ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.StopAsync().ConfigureAwait(false);
+    }
+
+    protected override IDeadLetterStore CreateStore() => _store;
+
+    private sealed class JsonEventSerializer : IEventSerializer
+    {
+        public ReadOnlyMemory<byte> Serialize<TEvent>(TEvent @event) where TEvent : notnull
+            => System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(@event));
+
+        public object Deserialize(ReadOnlyMemory<byte> data, Type targetType)
+            => JsonSerializer.Deserialize(System.Text.Encoding.UTF8.GetString(data.Span), targetType)
+               ?? throw new InvalidOperationException("Deserialization returned null");
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerProjectionStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerProjectionStoreTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Testcontainers.MsSql;
+using Xunit;
+using ZeroAlloc.EventSourcing;
+using ZeroAlloc.EventSourcing.Sql;
+using ZeroAlloc.EventSourcing.Tests;
+
+namespace ZeroAlloc.EventSourcing.Sql.Tests;
+
+[Collection("SqlServer")]
+public sealed class SqlServerProjectionStoreTests : ProjectionStoreContractTests, IAsyncLifetime
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest").Build();
+    private SqlServerProjectionStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        _store = new SqlServerProjectionStore(_container.GetConnectionString());
+        await _store.EnsureSchemaAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.StopAsync();
+    }
+
+    protected override IProjectionStore CreateStore() => _store;
+
+    [Fact]
+    public async Task EnsureSchemaAsync_IsIdempotent()
+    {
+        await _store.EnsureSchemaAsync(); // second call must not throw
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerSnapshotStoreTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Sql.Tests/SqlServerSnapshotStoreTests.cs
@@ -1,15 +1,20 @@
+using System.Text.Json;
 using FluentAssertions;
+using Testcontainers.MsSql;
 using ZeroAlloc.EventSourcing;
 using ZeroAlloc.EventSourcing.Sql;
 
 namespace ZeroAlloc.EventSourcing.Sql.Tests;
 
 /// <summary>
-/// Contract tests for <see cref="SqlServerSnapshotStore{TState}"/>.
+/// Contract tests for <see cref="SqlServerSnapshotStore{TState}"/> against a real SQL Server database.
 /// Inherits all contract tests from <see cref="SnapshotStoreContractTests{TStore}"/>.
 /// </summary>
-public class SqlServerSnapshotStoreTests : SnapshotStoreContractTests<SqlServerSnapshotStore<SnapshotTestState>>
+[Collection("SqlServer")]
+public sealed class SqlServerSnapshotStoreTests : SnapshotStoreContractTests<SqlServerSnapshotStore<SnapshotTestState>>
 {
+    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest").Build();
+
     /// <summary>Test that constructor rejects null connection string.</summary>
     [Fact]
     public void Constructor_NullConnectionString_ThrowsArgumentNullException()
@@ -34,39 +39,28 @@ public class SqlServerSnapshotStoreTests : SnapshotStoreContractTests<SqlServerS
             .Should().Throw<ArgumentException>();
     }
 
-    /// <summary>Test that constructor accepts valid connection string.</summary>
-    [Fact]
-    public void Constructor_ValidConnectionString_Succeeds()
-    {
-        const string connectionString = "Server=localhost;Database=test;User Id=sa;Password=YourPassword123!;Trust Server Certificate=true;";
-
-        FluentActions.Invoking(() => new SqlServerSnapshotStore<SnapshotTestState>(connectionString))
-            .Should().NotThrow();
-    }
-
     /// <inheritdoc/>
     protected override async Task<SqlServerSnapshotStore<SnapshotTestState>> CreateStoreAsync()
     {
-        const string connectionString = "Server=localhost;Database=test;User Id=sa;Password=YourPassword123!;Trust Server Certificate=true;";
-        var store = new SqlServerSnapshotStore<SnapshotTestState>(connectionString);
-        // EnsureSchemaAsync is called to initialize the database schema
-        // In real tests with a database, this would create the table
-        // For unit tests with dummy connection strings, this is a no-op
-        try
-        {
-            await store.EnsureSchemaAsync();
-        }
-        catch
-        {
-            // Ignore connection errors for unit tests with dummy connection strings
-        }
+        await _container.StartAsync();
+        var store = new SqlServerSnapshotStore<SnapshotTestState>(_container.GetConnectionString(), new JsonEventSerializer());
+        await store.EnsureSchemaAsync();
         return store;
     }
 
     /// <inheritdoc/>
     public override async Task DisposeAsync()
     {
-        // No resources to dispose for unit tests with dummy connection strings
-        await Task.CompletedTask;
+        await _container.StopAsync();
+    }
+
+    private sealed class JsonEventSerializer : IEventSerializer
+    {
+        public ReadOnlyMemory<byte> Serialize<TEvent>(TEvent @event) where TEvent : notnull
+            => System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(@event));
+
+        public object Deserialize(ReadOnlyMemory<byte> data, Type targetType)
+            => JsonSerializer.Deserialize(System.Text.Encoding.UTF8.GetString(data.Span), targetType)
+               ?? throw new InvalidOperationException("Deserialization returned null");
     }
 }

--- a/tests/ZeroAlloc.EventSourcing.Tests/DeadLetterStoreContractTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Tests/DeadLetterStoreContractTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Xunit;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Tests;
+
+public abstract class DeadLetterStoreContractTests
+{
+    protected abstract IDeadLetterStore CreateStore();
+
+    private static EventEnvelope MakeEnvelope() =>
+        new(new StreamId("test-stream"), new StreamPosition(1), new object(),
+            new EventMetadata(Guid.NewGuid(), "TestEvent", DateTimeOffset.UtcNow, null, null));
+
+    [Fact]
+    public async Task ReadAllAsync_Empty_ReturnsNothing()
+    {
+        var store = CreateStore();
+        var results = new List<DeadLetterEntry>();
+        await foreach (var e in store.ReadAllAsync())
+            results.Add(e);
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WriteAsync_SingleEntry_CanBeRead()
+    {
+        var store = CreateStore();
+        var envelope = MakeEnvelope();
+        var ex = new InvalidOperationException("boom");
+
+        await store.WriteAsync("consumer-1", envelope, ex);
+
+        var results = new List<DeadLetterEntry>();
+        await foreach (var e in store.ReadAllAsync())
+            results.Add(e);
+
+        results.Should().HaveCount(1);
+        results[0].ConsumerId.Should().Be("consumer-1");
+        results[0].ExceptionType.Should().Be(nameof(InvalidOperationException));
+        results[0].ExceptionMessage.Should().Be("boom");
+        results[0].Envelope.Metadata.EventId.Should().Be(envelope.Metadata.EventId);
+    }
+
+    [Fact]
+    public async Task WriteAsync_MultipleEntries_AllReadBack()
+    {
+        var store = CreateStore();
+        await store.WriteAsync("c1", MakeEnvelope(), new Exception("e1"));
+        await store.WriteAsync("c2", MakeEnvelope(), new Exception("e2"));
+
+        var results = new List<DeadLetterEntry>();
+        await foreach (var e in store.ReadAllAsync())
+            results.Add(e);
+
+        results.Should().HaveCount(2);
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Tests/ProjectionStoreContractTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Tests/ProjectionStoreContractTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Xunit;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Tests;
+
+public abstract class ProjectionStoreContractTests
+{
+    protected abstract IProjectionStore CreateStore();
+
+    [Fact]
+    public async Task Load_NonExistentKey_ReturnsNull()
+    {
+        var store = CreateStore();
+        var result = await store.LoadAsync("missing-key");
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Save_ThenLoad_RoundTrips()
+    {
+        var store = CreateStore();
+        await store.SaveAsync("orders", """{"count":5}""");
+        var result = await store.LoadAsync("orders");
+        result.Should().Be("""{"count":5}""");
+    }
+
+    [Fact]
+    public async Task Save_Overwrites_ExistingState()
+    {
+        var store = CreateStore();
+        await store.SaveAsync("orders", """{"count":1}""");
+        await store.SaveAsync("orders", """{"count":2}""");
+        var result = await store.LoadAsync("orders");
+        result.Should().Be("""{"count":2}""");
+    }
+
+    [Fact]
+    public async Task Clear_RemovesState()
+    {
+        var store = CreateStore();
+        await store.SaveAsync("orders", """{"count":1}""");
+        await store.ClearAsync("orders");
+        var result = await store.LoadAsync("orders");
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Clear_NonExistentKey_DoesNotThrow()
+    {
+        var store = CreateStore();
+        var act = async () => await store.ClearAsync("nonexistent");
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task MultipleKeys_AreIndependent()
+    {
+        var store = CreateStore();
+        await store.SaveAsync("proj-a", "state-a");
+        await store.SaveAsync("proj-b", "state-b");
+        (await store.LoadAsync("proj-a")).Should().Be("state-a");
+        (await store.LoadAsync("proj-b")).Should().Be("state-b");
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Tests/SnapshotPolicyTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Tests/SnapshotPolicyTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Xunit;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Tests;
+
+public class SnapshotPolicyTests
+{
+    [Theory]
+    [InlineData(10, null, 10, true)]    // no prior snapshot, 10 events → snapshot
+    [InlineData(10, 5, 15, true)]       // last at 5, now 15 → 10 since → snapshot
+    [InlineData(10, 5, 14, false)]      // last at 5, now 14 → only 9 since → no snapshot
+    [InlineData(10, 10, 19, false)]     // last at 10, now 19 → 9 since → no snapshot
+    [InlineData(10, 10, 20, true)]      // last at 10, now 20 → exactly 10 → snapshot
+    public void EveryNEvents_ShouldSnapshot_ReturnsExpected(
+        int n, int? lastSnapshot, int current, bool expected)
+    {
+        var policy = SnapshotPolicy.EveryNEvents(n);
+        var last = lastSnapshot.HasValue ? new StreamPosition(lastSnapshot.Value) : (StreamPosition?)null;
+        policy.ShouldSnapshot(new StreamPosition(current), last).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Always_ShouldSnapshot_AlwaysTrue()
+    {
+        SnapshotPolicy.Always.ShouldSnapshot(new StreamPosition(1), null).Should().BeTrue();
+        SnapshotPolicy.Always.ShouldSnapshot(new StreamPosition(100), new StreamPosition(99)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Never_ShouldSnapshot_AlwaysFalse()
+    {
+        SnapshotPolicy.Never.ShouldSnapshot(new StreamPosition(1), null).Should().BeFalse();
+        SnapshotPolicy.Never.ShouldSnapshot(new StreamPosition(1000), new StreamPosition(1)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EveryNEvents_NLessThanOne_ThrowsArgumentOutOfRangeException()
+    {
+        var act = () => SnapshotPolicy.EveryNEvents(0);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Tests/StreamConsumerDeadLetterTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Tests/StreamConsumerDeadLetterTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Xunit;
+using ZeroAlloc.EventSourcing;
+using ZeroAlloc.EventSourcing.InMemory;
+
+namespace ZeroAlloc.EventSourcing.Tests;
+
+public class StreamConsumerDeadLetterTests
+{
+    private readonly IEventStore _eventStore;
+    private readonly InMemoryCheckpointStore _checkpointStore = new();
+
+    public StreamConsumerDeadLetterTests()
+    {
+        _eventStore = new EventStore(
+            new InMemoryEventStoreAdapter(),
+            new JsonEventSerializer(),
+            new StreamConsumerTestEventTypeRegistry());
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_WithDeadLetterStrategy_RoutesFailedEventToStore()
+    {
+        var streamId = new StreamId("dl-stream");
+        await _eventStore.AppendAsync(streamId, new object[] { new TestEvent { Value = 42 } }.AsMemory(), StreamPosition.Start);
+
+        var deadLetterStore = new InMemoryDeadLetterStore();
+        var options = new StreamConsumerOptions
+        {
+            MaxRetries = 0,
+            ErrorStrategy = ErrorHandlingStrategy.DeadLetter
+        };
+        var consumer = new StreamConsumer(_eventStore, _checkpointStore, "consumer-dl-test", options, streamId, deadLetterStore);
+
+        await consumer.ConsumeAsync(async (envelope, ct) =>
+        {
+            throw new InvalidOperationException("handler-failure");
+        }, default);
+
+        var entries = new List<DeadLetterEntry>();
+        await foreach (var e in deadLetterStore.ReadAllAsync())
+            entries.Add(e);
+
+        entries.Should().HaveCount(1);
+        entries[0].ConsumerId.Should().Be("consumer-dl-test");
+        entries[0].ExceptionType.Should().Be(nameof(InvalidOperationException));
+        entries[0].ExceptionMessage.Should().Be("handler-failure");
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_DeadLetterWithoutStore_Throws()
+    {
+        var streamId = new StreamId("dl-nostore-stream");
+        await _eventStore.AppendAsync(streamId, new object[] { new TestEvent { Value = 1 } }.AsMemory(), StreamPosition.Start);
+
+        var options = new StreamConsumerOptions
+        {
+            MaxRetries = 0,
+            ErrorStrategy = ErrorHandlingStrategy.DeadLetter
+        };
+        // No dead-letter store passed
+        var consumer = new StreamConsumer(_eventStore, _checkpointStore, "consumer-dl-nostore", options, streamId);
+
+        Func<Task> action = async () =>
+        {
+            await consumer.ConsumeAsync(async (envelope, ct) =>
+            {
+                throw new InvalidOperationException("handler-failure");
+            }, default);
+        };
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*dead-letter store*");
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Tests/StreamConsumerTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Tests/StreamConsumerTests.cs
@@ -222,7 +222,8 @@ public class StreamConsumerTests
             }, default);
         };
 
-        await action.Should().ThrowAsync<NotSupportedException>();
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*dead-letter store*");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **SqlServerCheckpointStore** — SQL Server implementation of `ICheckpointStore` using `MERGE` upsert for consumer position tracking
- **ISnapshotPolicy** — Pluggable snapshot write policy (`Always`, `Never`, `EveryNEvents(n)`) wired into `SnapshotCachingRepositoryDecorator`
- **IDeadLetterStore** — Dead-letter abstraction with `InMemoryDeadLetterStore`, `PostgreSqlDeadLetterStore`, `SqlServerDeadLetterStore`; wired into both `StreamConsumer` and `KafkaStreamConsumer`
- **SQL-backed IProjectionStore** — `PostgreSqlProjectionStore` + `SqlServerProjectionStore` for read model state persistence with 256-char key validation
- **Multi-partition Kafka** — `KafkaConsumerOptions.Partitions` (`int[]`, default `[0]`) replaces `Partition` (`int`); per-partition checkpoint keying with `ConcurrentDictionary` for thread safety
- **Fix** — Snapshot store contract tests converted from hardcoded `localhost` to Testcontainers
- **Fix** — `SnapshotCachingRepositoryDecorator` restored backward compatibility for `IgnoreSnapshot` strategy with null `aggregateFactory`
- **Fix** — Roslyn generator pinned to 5.0.0 via `VersionOverride` for local SDK compatibility

## Test Plan

- [ ] Unit tests: 176 passing (EventSourcing, Aggregates, InMemory, Kafka)
- [ ] Integration tests run via Testcontainers: PostgreSQL + SQL Server for CheckpointStore, ProjectionStore, SnapshotStore, DeadLetterStore
- [ ] All new SQL stores follow existing MERGE/ON CONFLICT upsert patterns
- [ ] Multi-partition Kafka: existing single-partition behavior preserved by `Partitions = [0]` default
- [ ] Dead-letter strategy tested end-to-end in both `StreamConsumer` and `KafkaStreamConsumer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)