### PR TITLE
fix: move ZeroAlloc.Telemetry and ZeroAlloc.StateMachine into CPM; bump Meziantou.Analyzer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,9 @@
     <PackageVersion Include="ZeroAlloc.Serialisation"            Version="2.0.0" />
     <PackageVersion Include="ZeroAlloc.Pipeline"                 Version="0.1.6" />
     <PackageVersion Include="ZeroAlloc.Analyzers"                Version="1.3.13" />
-    <PackageVersion Include="Meziantou.Analyzer"                 Version="3.0.52" />
+    <PackageVersion Include="Meziantou.Analyzer"                 Version="3.0.54" />
+    <PackageVersion Include="ZeroAlloc.Telemetry"               Version="1.1.0" />
+    <PackageVersion Include="ZeroAlloc.StateMachine"            Version="1.0.1" />
     <PackageVersion Include="Roslynator.Analyzers"               Version="4.15.0" />
     <PackageVersion Include="xunit"                              Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio"          Version="3.1.5" />

--- a/src/ZeroAlloc.EventSourcing.Aggregates/ZeroAlloc.EventSourcing.Aggregates.csproj
+++ b/src/ZeroAlloc.EventSourcing.Aggregates/ZeroAlloc.EventSourcing.Aggregates.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="ZeroAlloc.Collections" />
     <PackageReference Include="ZeroAlloc.Results" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="ZeroAlloc.StateMachine" Version="1.0.0" />
+    <PackageReference Include="ZeroAlloc.StateMachine" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ZeroAlloc.EventSourcing/ZeroAlloc.EventSourcing.csproj
+++ b/src/ZeroAlloc.EventSourcing/ZeroAlloc.EventSourcing.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="ZeroAlloc.AsyncEvents" />
     <PackageReference Include="ZeroAlloc.ValueObjects" />
     <PackageReference Include="ZeroAlloc.Serialisation" />
-    <PackageReference Include="ZeroAlloc.Telemetry" Version="1.0.0" />
+    <PackageReference Include="ZeroAlloc.Telemetry" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Add `ZeroAlloc.Telemetry 1.1.0` and `ZeroAlloc.StateMachine 1.0.1` to `Directory.Packages.props` — both packages had inline `Version` in their csproj files but were absent from CPM, causing `NU1008` on every CI run
- Remove the inline `Version` attributes from `ZeroAlloc.EventSourcing.csproj` and `ZeroAlloc.EventSourcing.Aggregates.csproj`
- Bump `Meziantou.Analyzer` to `3.0.54` in CPM (absorbs Renovate PRs #73, #74, #75 — those can be closed after this merges)

## Test plan
- [ ] CI build passes (no NU1008)
- [ ] Renovate PRs #73, #74, #75 can be closed as superseded

🤖 Generated with [Claude Code](https://claude.com/claude-code)