### PR TITLE
feat: aggregate state-machine validation via companion FSM (#67)

### DIFF
--- a/docs/core-concepts/aggregates.md
+++ b/docs/core-concepts/aggregates.md
@@ -472,3 +472,54 @@ Aggregates sit at the heart of event sourcing: they translate commands into immu
 - **[Core Concepts: Events](./events.md)** — The events aggregates raise
 - **[Core Concepts: Event Store](./event-store.md)** — How events are persisted
 - **[Quick Start Example](../getting-started/quick-start-example.md)** — Complete working Order aggregate
+
+## State-machine validation
+
+When an aggregate has a clear lifecycle — `Draft → Placed → Shipped` — declaring the legal transitions in a companion `[StateMachine]` partial class lets the compiler emit a `TryFire` switch that rejects illegal commands at the call site. The aggregate's authoritative status lives on the state struct; the FSM is constructed per command so the two representations cannot drift.
+
+### The pattern
+
+Two parts:
+
+1. A status enum on the state struct.
+2. A companion partial class with `[StateMachine]` and `[Transition<TStatus, TTrigger>]` attributes. The constructor seeds the FSM's internal state from the aggregate's current status.
+
+```csharp
+public enum OrderStatus  { Draft, Placed, Shipped, Cancelled }
+public enum OrderTrigger { Place, Ship, Cancel }
+
+[StateMachine(InitialState = nameof(OrderStatus.Draft))]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Draft,  On = OrderTrigger.Place,  To = OrderStatus.Placed)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Placed, On = OrderTrigger.Ship,   To = OrderStatus.Shipped)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Draft,  On = OrderTrigger.Cancel, To = OrderStatus.Cancelled)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Placed, On = OrderTrigger.Cancel, To = OrderStatus.Cancelled)]
+[Terminal<OrderStatus>(State = OrderStatus.Shipped)]
+[Terminal<OrderStatus>(State = OrderStatus.Cancelled)]
+public sealed partial class OrderFsm
+{
+    public OrderFsm(OrderStatus current) => _state = current;
+}
+```
+
+The aggregate command method validates before raising:
+
+```csharp
+public void Ship(string trackingNumber)
+{
+    var fsm = new OrderFsm(State.Status);
+    if (!fsm.TryFire(OrderTrigger.Ship))
+        throw new InvalidOperationException($"Cannot ship order in status {State.Status}.");
+    Raise(new OrderShipped(trackingNumber));
+}
+```
+
+### Compensation paths
+
+Multiple `[Transition]` lines from different source states to the same target encode compensation. The two `Cancel` transitions above let an order be cancelled from either `Draft` or `Placed`, but not after `Shipped` (no transition declared) or `Cancelled` (`[Terminal]`).
+
+### What this does and does not replace
+
+- **Does** validate that a command is legal in the current status — illegal transitions throw `InvalidOperationException` before the event is raised.
+- **Does not** replace the event-to-state dispatch that `AggregateDispatchGenerator` already emits (`ApplyEvent` continues to route events to `state.Apply(...)` methods).
+
+For the FSM attribute reference and analyzer warnings (e.g., ZSM0003 on self-loops), see the [ZeroAlloc.StateMachine documentation](https://github.com/ZeroAlloc-Net/ZeroAlloc.StateMachine).

--- a/samples/ZeroAlloc.EventSourcing.AotSmoke/Domain.cs
+++ b/samples/ZeroAlloc.EventSourcing.AotSmoke/Domain.cs
@@ -1,5 +1,6 @@
 using System;
 using ZeroAlloc.EventSourcing.Aggregates;
+using ZeroAlloc.StateMachine;
 
 namespace ZeroAlloc.EventSourcing.AotSmoke;
 
@@ -7,30 +8,74 @@ namespace ZeroAlloc.EventSourcing.AotSmoke;
 
 public readonly record struct OrderId(Guid Value);
 
+public enum OrderStatus { Draft, Placed, Shipped, Cancelled }
+public enum OrderTrigger { Place, Ship, Cancel }
+
 public record OrderPlacedEvent(string OrderId, decimal Total);
 public record OrderShippedEvent(string TrackingNumber);
+public record OrderCancelledEvent(string Reason);
+
+#pragma warning disable ZSM0003 // Place/Ship triggers each appear in only one transition by design — the lifecycle is linear (Draft → Placed → Shipped) and these single-edge triggers are intentional
+[StateMachine(InitialState = nameof(OrderStatus.Draft))]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Draft,  On = OrderTrigger.Place,  To = OrderStatus.Placed)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Placed, On = OrderTrigger.Ship,   To = OrderStatus.Shipped)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Draft,  On = OrderTrigger.Cancel, To = OrderStatus.Cancelled)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Placed, On = OrderTrigger.Cancel, To = OrderStatus.Cancelled)]
+[Terminal<OrderStatus>(State = OrderStatus.Shipped)]
+[Terminal<OrderStatus>(State = OrderStatus.Cancelled)]
+public sealed partial class OrderFsm
+{
+    public OrderFsm(OrderStatus current) => _state = current;
+}
+#pragma warning restore ZSM0003
 
 public partial struct OrderState : IAggregateState<OrderState>
 {
     public static OrderState Initial => default;
-    public bool IsPlaced { get; private set; }
-    public bool IsShipped { get; private set; }
+    public OrderStatus Status { get; private set; }
+    public bool IsPlaced => Status == OrderStatus.Placed || Status == OrderStatus.Shipped;
+    public bool IsShipped => Status == OrderStatus.Shipped;
+    public bool IsCancelled => Status == OrderStatus.Cancelled;
     public decimal Total { get; private set; }
 
-    internal OrderState Apply(OrderPlacedEvent e) => this with { IsPlaced = true, Total = e.Total };
-    internal OrderState Apply(OrderShippedEvent _) => this with { IsShipped = true };
+    internal OrderState Apply(OrderPlacedEvent e)    => this with { Status = OrderStatus.Placed,    Total = e.Total };
+    internal OrderState Apply(OrderShippedEvent _)   => this with { Status = OrderStatus.Shipped };
+    internal OrderState Apply(OrderCancelledEvent _) => this with { Status = OrderStatus.Cancelled };
 }
 
 public sealed partial class Order : Aggregate<OrderId, OrderState>
 {
-    public void Place(string orderId, decimal total) => Raise(new OrderPlacedEvent(orderId, total));
-    public void Ship(string tracking) => Raise(new OrderShippedEvent(tracking));
+    public void Place(string orderId, decimal total)
+    {
+        var fsm = new OrderFsm(State.Status);
+        if (!fsm.TryFire(OrderTrigger.Place))
+            throw new InvalidOperationException($"Cannot place order in status {State.Status}.");
+        Raise(new OrderPlacedEvent(orderId, total));
+    }
+
+    public void Ship(string tracking)
+    {
+        var fsm = new OrderFsm(State.Status);
+        if (!fsm.TryFire(OrderTrigger.Ship))
+            throw new InvalidOperationException($"Cannot ship order in status {State.Status}.");
+        Raise(new OrderShippedEvent(tracking));
+    }
+
+    public void Cancel(string reason)
+    {
+        var fsm = new OrderFsm(State.Status);
+        if (!fsm.TryFire(OrderTrigger.Cancel))
+            throw new InvalidOperationException($"Cannot cancel order in status {State.Status}.");
+        Raise(new OrderCancelledEvent(reason));
+    }
+
     public void SetId(OrderId id) => Id = id;
 
     protected override OrderState ApplyEvent(OrderState state, object @event) => @event switch
     {
         OrderPlacedEvent p => state.Apply(p),
         OrderShippedEvent s => state.Apply(s),
+        OrderCancelledEvent c => state.Apply(c),
         _ => state,
     };
 }

--- a/samples/ZeroAlloc.EventSourcing.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.EventSourcing.AotSmoke/Program.cs
@@ -2,35 +2,63 @@ using System;
 using ZeroAlloc.EventSourcing.AotSmoke;
 
 // Exercise the generator-backed Aggregate<TId, TState> + Raise/ApplyEvent flow
-// under PublishAot=true. Confirms events persist into the uncommitted list
-// and state transitions through ApplyEvent without reflection.
+// AND the ZeroAlloc.StateMachine companion FSM transition validation under
+// PublishAot=true. Confirms events persist into the uncommitted list, state
+// transitions through ApplyEvent, and illegal transitions throw without
+// reflection.
 
-using var order = new Order();
-order.SetId(new OrderId(Guid.NewGuid()));
-order.Place(orderId: "ord-1", total: 99.95m);
-order.Ship(tracking: "pkg-1");
+// Path 1: happy path — Place then Ship
+{
+    using var order = new Order();
+    order.SetId(new OrderId(Guid.NewGuid()));
+    order.Place(orderId: "ord-1", total: 99.95m);
+    order.Ship(tracking: "pkg-1");
 
-if (!order.State.IsPlaced)
-{
-    Console.Error.WriteLine("AOT smoke: FAIL — state.IsPlaced should be true after Place");
-    return 1;
-}
-if (!order.State.IsShipped)
-{
-    Console.Error.WriteLine("AOT smoke: FAIL — state.IsShipped should be true after Ship");
-    return 1;
-}
-if (order.State.Total != 99.95m)
-{
-    Console.Error.WriteLine($"AOT smoke: FAIL — Total expected 99.95, got {order.State.Total}");
-    return 1;
+    if (!order.State.IsPlaced)
+    {
+        Console.Error.WriteLine("AOT smoke: FAIL — state.IsPlaced should be true after Place");
+        return 1;
+    }
+    if (!order.State.IsShipped)
+    {
+        Console.Error.WriteLine("AOT smoke: FAIL — state.IsShipped should be true after Ship");
+        return 1;
+    }
+    if (order.State.Total != 99.95m)
+    {
+        Console.Error.WriteLine($"AOT smoke: FAIL — Total expected 99.95, got {order.State.Total}");
+        return 1;
+    }
+    if (order.Version.Value != 2)
+    {
+        Console.Error.WriteLine($"AOT smoke: FAIL — Version expected 2, got {order.Version.Value}");
+        return 1;
+    }
 }
 
-// DequeueUncommitted is internal; Version is the public bookkeeping signal.
-if (order.Version.Value != 2)
+// Path 2: compensation path — Place then Cancel, then Ship must throw
 {
-    Console.Error.WriteLine($"AOT smoke: FAIL — Version expected 2 after two Raise() calls, got {order.Version.Value}");
-    return 1;
+    using var order = new Order();
+    order.SetId(new OrderId(Guid.NewGuid()));
+    order.Place(orderId: "ord-2", total: 50m);
+    order.Cancel(reason: "AOT smoke compensation test");
+
+    if (!order.State.IsCancelled)
+    {
+        Console.Error.WriteLine("AOT smoke: FAIL — state.IsCancelled should be true after Cancel");
+        return 1;
+    }
+
+    try
+    {
+        order.Ship(tracking: "should-throw");
+        Console.Error.WriteLine("AOT smoke: FAIL — Ship after Cancel should have thrown InvalidOperationException");
+        return 1;
+    }
+    catch (InvalidOperationException)
+    {
+        // expected — FSM rejected the illegal transition
+    }
 }
 
 Console.WriteLine("AOT smoke: PASS");

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
@@ -53,4 +53,16 @@ public class AggregateStateMachineTests
             .WithMessage("*Draft*");
         order.State.Status.Should().Be(OrderStatus.Draft); // unchanged
     }
+
+    [Fact]
+    public void Cancel_FromPlaced_Succeeds()
+    {
+        var order = new Order();
+        order.PlaceOrder(total: 100m);
+
+        order.Cancel(reason: "out of stock");
+
+        order.State.Status.Should().Be(OrderStatus.Cancelled);
+        order.State.CancelReason.Should().Be("out of stock");
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
@@ -5,5 +5,15 @@ namespace ZeroAlloc.EventSourcing.Aggregates.Tests.Lifecycle;
 
 public class AggregateStateMachineTests
 {
-    // Test cases added in Tasks 7-12 below.
+    [Fact]
+    public void Place_FromDraft_Succeeds()
+    {
+        var order = new Order();
+
+        order.PlaceOrder(total: 100m);
+
+        order.State.Status.Should().Be(OrderStatus.Placed);
+        order.State.Total.Should().Be(100m);
+        order.Version.Value.Should().Be(1);
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
@@ -65,4 +65,18 @@ public class AggregateStateMachineTests
         order.State.Status.Should().Be(OrderStatus.Cancelled);
         order.State.CancelReason.Should().Be("out of stock");
     }
+
+    [Fact]
+    public void Ship_AfterCancel_Throws()
+    {
+        var order = new Order();
+        order.PlaceOrder(total: 100m);
+        order.Cancel(reason: "customer changed mind");
+
+        var act = () => order.Ship(trackingNumber: "TRACK-1");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cancelled*");
+        order.State.Status.Should().Be(OrderStatus.Cancelled);
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
@@ -29,4 +29,16 @@ public class AggregateStateMachineTests
             .WithMessage("*Placed*");
         order.State.Total.Should().Be(100m); // unchanged
     }
+
+    [Fact]
+    public void Ship_FromPlaced_Succeeds()
+    {
+        var order = new Order();
+        order.PlaceOrder(total: 100m);
+
+        order.Ship(trackingNumber: "TRACK-1");
+
+        order.State.Status.Should().Be(OrderStatus.Shipped);
+        order.State.TrackingNumber.Should().Be("TRACK-1");
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
@@ -1,0 +1,9 @@
+using FluentAssertions;
+using ZeroAlloc.EventSourcing;
+
+namespace ZeroAlloc.EventSourcing.Aggregates.Tests.Lifecycle;
+
+public class AggregateStateMachineTests
+{
+    // Test cases added in Tasks 7-12 below.
+}

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
@@ -41,4 +41,16 @@ public class AggregateStateMachineTests
         order.State.Status.Should().Be(OrderStatus.Shipped);
         order.State.TrackingNumber.Should().Be("TRACK-1");
     }
+
+    [Fact]
+    public void Ship_FromDraft_Throws()
+    {
+        var order = new Order();
+
+        var act = () => order.Ship(trackingNumber: "TRACK-1");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Draft*");
+        order.State.Status.Should().Be(OrderStatus.Draft); // unchanged
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/AggregateStateMachineTests.cs
@@ -16,4 +16,17 @@ public class AggregateStateMachineTests
         order.State.Total.Should().Be(100m);
         order.Version.Value.Should().Be(1);
     }
+
+    [Fact]
+    public void Place_FromPlaced_Throws()
+    {
+        var order = new Order();
+        order.PlaceOrder(total: 100m);
+
+        var act = () => order.PlaceOrder(total: 50m);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Placed*");
+        order.State.Total.Should().Be(100m); // unchanged
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Events.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Events.cs
@@ -1,0 +1,5 @@
+namespace ZeroAlloc.EventSourcing.Aggregates.Tests.Lifecycle;
+
+public record OrderPlaced(decimal Total);
+public record OrderShipped(string TrackingNumber);
+public record OrderCancelled(string Reason);

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Order.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Order.cs
@@ -26,4 +26,13 @@ public sealed partial class Order : Aggregate<OrderId, OrderState>
                 $"Cannot ship order in status {State.Status}.");
         Raise(new OrderShipped(trackingNumber));
     }
+
+    public void Cancel(string reason)
+    {
+        var fsm = new OrderFsm(State.Status);
+        if (!fsm.TryFire(OrderTrigger.Cancel))
+            throw new InvalidOperationException(
+                $"Cannot cancel order in status {State.Status}.");
+        Raise(new OrderCancelled(reason));
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Order.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Order.cs
@@ -8,4 +8,13 @@ public sealed partial class Order : Aggregate<OrderId, OrderState>
 {
     // FSM-validated command methods are added test-by-test in Tasks 7, 9, 11.
     public void SetId(OrderId id) => Id = id;
+
+    public void PlaceOrder(decimal total)
+    {
+        var fsm = new OrderFsm(State.Status);
+        if (!fsm.TryFire(OrderTrigger.Place))
+            throw new InvalidOperationException(
+                $"Cannot place order in status {State.Status}.");
+        Raise(new OrderPlaced(total));
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Order.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Order.cs
@@ -17,4 +17,13 @@ public sealed partial class Order : Aggregate<OrderId, OrderState>
                 $"Cannot place order in status {State.Status}.");
         Raise(new OrderPlaced(total));
     }
+
+    public void Ship(string trackingNumber)
+    {
+        var fsm = new OrderFsm(State.Status);
+        if (!fsm.TryFire(OrderTrigger.Ship))
+            throw new InvalidOperationException(
+                $"Cannot ship order in status {State.Status}.");
+        Raise(new OrderShipped(trackingNumber));
+    }
 }

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Order.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/Order.cs
@@ -1,0 +1,11 @@
+using ZeroAlloc.EventSourcing.Aggregates;
+
+namespace ZeroAlloc.EventSourcing.Aggregates.Tests.Lifecycle;
+
+public readonly record struct OrderId(Guid Value);
+
+public sealed partial class Order : Aggregate<OrderId, OrderState>
+{
+    // FSM-validated command methods are added test-by-test in Tasks 7, 9, 11.
+    public void SetId(OrderId id) => Id = id;
+}

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/OrderFsm.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/OrderFsm.cs
@@ -1,0 +1,17 @@
+#pragma warning disable ZSM0003 // Place/Ship triggers each appear in only one transition by design — the lifecycle is linear (Draft → Placed → Shipped) and these single-edge triggers are intentional
+
+using ZeroAlloc.StateMachine;
+
+namespace ZeroAlloc.EventSourcing.Aggregates.Tests.Lifecycle;
+
+[StateMachine(InitialState = nameof(OrderStatus.Draft))]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Draft,  On = OrderTrigger.Place,  To = OrderStatus.Placed)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Placed, On = OrderTrigger.Ship,   To = OrderStatus.Shipped)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Draft,  On = OrderTrigger.Cancel, To = OrderStatus.Cancelled)]
+[Transition<OrderStatus, OrderTrigger>(From = OrderStatus.Placed, On = OrderTrigger.Cancel, To = OrderStatus.Cancelled)]
+[Terminal<OrderStatus>(State = OrderStatus.Shipped)]
+[Terminal<OrderStatus>(State = OrderStatus.Cancelled)]
+public sealed partial class OrderFsm
+{
+    public OrderFsm(OrderStatus current) => _state = current;
+}

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/OrderState.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/OrderState.cs
@@ -1,0 +1,17 @@
+using ZeroAlloc.EventSourcing.Aggregates;
+
+namespace ZeroAlloc.EventSourcing.Aggregates.Tests.Lifecycle;
+
+public partial struct OrderState : IAggregateState<OrderState>
+{
+    public static OrderState Initial => default; // Status defaults to OrderStatus.Draft (enum value 0)
+
+    public OrderStatus Status { get; private set; }
+    public decimal Total { get; private set; }
+    public string? TrackingNumber { get; private set; }
+    public string? CancelReason { get; private set; }
+
+    internal OrderState Apply(OrderPlaced e)    => this with { Status = OrderStatus.Placed,    Total = e.Total };
+    internal OrderState Apply(OrderShipped e)   => this with { Status = OrderStatus.Shipped,   TrackingNumber = e.TrackingNumber };
+    internal OrderState Apply(OrderCancelled e) => this with { Status = OrderStatus.Cancelled, CancelReason = e.Reason };
+}

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/OrderStatus.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/OrderStatus.cs
@@ -1,0 +1,9 @@
+namespace ZeroAlloc.EventSourcing.Aggregates.Tests.Lifecycle;
+
+public enum OrderStatus
+{
+    Draft,
+    Placed,
+    Shipped,
+    Cancelled,
+}

--- a/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/OrderTrigger.cs
+++ b/tests/ZeroAlloc.EventSourcing.Aggregates.Tests/Lifecycle/OrderTrigger.cs
@@ -1,0 +1,8 @@
+namespace ZeroAlloc.EventSourcing.Aggregates.Tests.Lifecycle;
+
+public enum OrderTrigger
+{
+    Place,
+    Ship,
+    Cancel,
+}


### PR DESCRIPTION
Closes #67.

## Summary
- Introduces the companion `[StateMachine]` partial class pattern for aggregate transition validation (mirrors `OutboxMessageFsm` / `JobStatusFsm` shipped in the Outbox and Scheduling repos).
- Aggregate command methods construct a per-call FSM from `State.Status`, call `TryFire`, and `Raise` only when the transition is legal.
- `AggregateDispatchGenerator`s `ApplyEvent` dispatch is unchanged.

## Acceptance criteria from issue #67
- [x] `ZeroAlloc.EventSourcing.Aggregates.csproj` references `ZeroAlloc.StateMachine` (already wired)
- [x] `[StateMachine]` companion class emits `TryFire` validation method (per Outbox/Scheduling pattern)
- [x] Existing `Aggregates.Tests` pass (no source changes to the Aggregates project; 36 baseline + 6 new = 42 total)
- [x] New integration test: `AggregateStateMachineTests` covering transition + compensation (6 tests, including `Ship_AfterCancel_Throws`)
- [x] `ZeroAlloc.EventSourcing.AotSmoke` still publishes (compensation path added to Domain.cs + Program.cs; AOT publish verified locally)
- [x] `docs/core-concepts/aggregates.md` describes the state-machine authoring pattern (new "State-machine validation" section)
- [x] Matrix row 6 updated and this issue linked

## Test plan
- [x] `dotnet test` (full Aggregates test suite) — 42/42 passing locally
- [x] `dotnet publish samples/ZeroAlloc.EventSourcing.AotSmoke -c Release` — AOT publish succeeds with no IL errors; published binary exits 0

## Implementation notes
- Companion-class FSM (separate `OrderFsm` partial class) is the chosen pattern over embedding `[StateMachine]` directly on the aggregate. Reasons: identical to shipped Outbox/Scheduling pattern, no `Aggregate<TId, TState>` base-class change, no sync drift possible (FSM constructed fresh per command).
- `#pragma warning disable ZSM0003` on `OrderFsm` declarations because the linear lifecycle has single-edge `Place`/`Ship` triggers; this matches the precedent in `OutboxMessageFsm` and `JobStatusFsm`.

## Design + plan
- Design: [`docs/plans/2026-04-25-eventsourcing-statemachine-design.md`](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing) (parent docs folder)
- Plan: [`docs/plans/2026-04-25-eventsourcing-statemachine-plan.md`](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing) (parent docs folder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)