### PR TITLE
feat(eventsourcing.telemetry): add WithTelemetry alias for UseEventSourcingTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ dotnet add package ZeroAlloc.EventSourcing.Telemetry
 services
     .AddEventSourcing()
     .UseInMemoryEventStore()
-    .UseEventSourcingTelemetry();   // call after the store, before Build()
+    .WithTelemetry();   // call after the store, before Build()
 ```
 
 The decorator emits:
@@ -155,7 +155,7 @@ The decorator emits:
 
 Any OpenTelemetry SDK wired to the process automatically picks up both instruments via the `ZeroAlloc.EventSourcing` meter/activity-source name.
 
-> **Migration note:** `InstrumentedEventStore` (the manual wrapper from earlier versions) is now `[Obsolete]`. Use `.UseEventSourcingTelemetry()` instead; it wires the same source-generated proxy with correct lifecycle management.
+> **Migration note:** `InstrumentedEventStore` (the manual wrapper from earlier versions) is now `[Obsolete]`. Use `.WithTelemetry()` instead; it wires the same source-generated proxy with correct lifecycle management. Renamed from `UseEventSourcingTelemetry()` for consistency with the rest of the ecosystem; old name remains as `[Obsolete]` for one minor version.
 
 ## Documentation
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -55,7 +55,7 @@ await repo.SaveAsync("order-1", order, CancellationToken.None);
 | `ZeroAlloc.EventSourcing.InMemory` | In-memory event store for tests and development |
 | `ZeroAlloc.EventSourcing.Sql` | SQL Server and PostgreSQL backends |
 | `ZeroAlloc.EventSourcing.Generators` | Roslyn source generators for aggregate boilerplate |
-| `ZeroAlloc.EventSourcing.Telemetry` | BCL ActivitySource + Meter decorator — spans and metrics with no OTel SDK |
+| `ZeroAlloc.EventSourcing.Telemetry` | BCL `ActivitySource` + `Meter` decorator — spans and metrics; wire with `.WithTelemetry()` |
 
 ## Documentation
 
@@ -92,9 +92,11 @@ await repo.SaveAsync("order-1", order, CancellationToken.None);
 - **[Plugin Architecture](advanced/plugin-architecture.md)** - Build extensible systems with plugins
 - **[Contributing Guide](advanced/contributing.md)** - How to contribute to the project
 
+### Observability
+- **[OpenTelemetry Instrumentation](telemetry.md)** - Activity spans and metrics via `WithTelemetry()`
+
 ### Additional Resources
 - **[Adoption Guide](ADOPTION_GUIDE.md)** - Business case and adoption strategy
-- **[Latest News](../PHASE5_FINAL_REVIEW.md)** - Recent updates and improvements
 
 ## Learning Paths
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -16,14 +16,16 @@ dotnet add package ZeroAlloc.EventSourcing.Telemetry
 
 ## Registration
 
-Call `.UseEventSourcingTelemetry()` **after** registering a store backend and **before** building the service provider:
+Call `.WithTelemetry()` **after** registering a store backend and **before** building the service provider:
 
 ```csharp
 services
     .AddEventSourcing()
     .UseInMemoryEventStore()          // or UsePostgreSqlEventStore(), etc.
-    .UseEventSourcingTelemetry();     // wraps the store with the instrumented decorator
+    .WithTelemetry();                 // wraps the store with the instrumented decorator
 ```
+
+> Renamed from `UseEventSourcingTelemetry()` for consistency with the rest of the ecosystem; old name remains as `[Obsolete]` for one minor version.
 
 The extension replaces the existing `IEventStore` registration with a source-generated `EventStoreInstrumented` wrapper. Any code that resolves `IEventStore` gets the decorated version automatically.
 
@@ -60,7 +62,7 @@ services
     .AddEventSourcing()
     .AddAggregates()
     .UseInMemoryEventStore()
-    .UseEventSourcingTelemetry();
+    .WithTelemetry();
 ```
 
 The `InstrumentedAggregateRepository` decorator adds spans for `LoadAsync` and `SaveAsync`.
@@ -78,7 +80,7 @@ services.AddSingleton<IEventStore>(sp =>
 services
     .AddEventSourcing()
     .UseMyEventStore()
-    .UseEventSourcingTelemetry();
+    .WithTelemetry();
 ```
 
-The source-generated `EventStoreInstrumented` used internally by `UseEventSourcingTelemetry()` is equivalent but avoids the double-Meter anti-pattern that `InstrumentedEventStore` exhibited.
+The source-generated `EventStoreInstrumented` used internally by `WithTelemetry()` is equivalent but avoids the double-Meter anti-pattern that `InstrumentedEventStore` exhibited.

--- a/src/ZeroAlloc.EventSourcing.Telemetry/EventSourcingBuilderExtensions.cs
+++ b/src/ZeroAlloc.EventSourcing.Telemetry/EventSourcingBuilderExtensions.cs
@@ -13,12 +13,12 @@ public static class EventSourcingBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="EventSourcingBuilder"/> to configure.</param>
     /// <returns>The same <paramref name="builder"/> instance for chaining.</returns>
-    public static EventSourcingBuilder UseEventSourcingTelemetry(this EventSourcingBuilder builder)
+    public static EventSourcingBuilder WithTelemetry(this EventSourcingBuilder builder)
     {
         var descriptor = builder.Services.FirstOrDefault(d => d.ServiceType == typeof(IEventStore));
         if (descriptor is null)
             throw new InvalidOperationException(
-                "No IEventStore registration found. Register an event store (e.g. UseInMemoryEventStore, UsePostgreSqlEventStore) before calling UseEventSourcingTelemetry.");
+                "No IEventStore registration found. Register an event store (e.g. UseInMemoryEventStore, UsePostgreSqlEventStore) before calling WithTelemetry.");
 
         builder.Services.Remove(descriptor);
         builder.Services.AddSingleton<IEventStore>(sp =>
@@ -35,4 +35,13 @@ public static class EventSourcingBuilderExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Legacy alias for <see cref="WithTelemetry"/>. Use <see cref="WithTelemetry"/> instead.
+    /// </summary>
+    /// <param name="builder">The <see cref="EventSourcingBuilder"/> to configure.</param>
+    /// <returns>The same <paramref name="builder"/> instance for chaining.</returns>
+    [Obsolete("Use WithTelemetry() instead. Will be removed in the next major.", DiagnosticId = "ZAES001")]
+    public static EventSourcingBuilder UseEventSourcingTelemetry(this EventSourcingBuilder builder)
+        => builder.WithTelemetry();
 }

--- a/tests/ZeroAlloc.EventSourcing.Telemetry.Tests/WithTelemetryTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Telemetry.Tests/WithTelemetryTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using ZeroAlloc.EventSourcing;
+using ZeroAlloc.EventSourcing.InMemory;
+using ZeroAlloc.Serialisation;
+
+namespace ZeroAlloc.EventSourcing.Telemetry.Tests;
+
+public class WithTelemetryTests
+{
+    private static IServiceCollection BaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IEventTypeRegistry>());
+        services.AddSingleton(Substitute.For<ISerializerDispatcher>());
+        return services;
+    }
+
+    [Fact]
+    public void WithTelemetry_RegistersInstrumentedEventStore()
+    {
+        var services = BaseServices();
+        services.AddEventSourcing()
+                .UseInMemoryEventStore()
+                .WithTelemetry();
+
+        var sp = services.BuildServiceProvider();
+        var store = sp.GetRequiredService<IEventStore>();
+        store.GetType().Name.Should().Contain("Instrumented");
+    }
+
+    [Fact]
+    public void UseEventSourcingTelemetry_LegacyShim_StillWraps()
+    {
+        var services = BaseServices();
+#pragma warning disable CS0618 // exercise the legacy shim
+        services.AddEventSourcing()
+                .UseInMemoryEventStore()
+                .UseEventSourcingTelemetry();
+#pragma warning restore CS0618
+
+        var sp = services.BuildServiceProvider();
+        sp.GetRequiredService<IEventStore>().GetType().Name.Should().Contain("Instrumented");
+    }
+}

--- a/tests/ZeroAlloc.EventSourcing.Telemetry.Tests/ZeroAlloc.EventSourcing.Telemetry.Tests.csproj
+++ b/tests/ZeroAlloc.EventSourcing.Telemetry.Tests/ZeroAlloc.EventSourcing.Telemetry.Tests.csproj
@@ -7,6 +7,8 @@
     <IsPackable>false</IsPackable>
     <!-- Suppress CS1591: test classes don't need XML doc comments -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!-- Tests intentionally exercise the [Obsolete] UseEventSourcingTelemetry shim. -->
+    <NoWarn>$(NoWarn);ZAES001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ZeroAlloc.EventSourcing.Telemetry\ZeroAlloc.EventSourcing.Telemetry.csproj" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.EventSourcing.InMemory\ZeroAlloc.EventSourcing.InMemory.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Adds `EventSourcingBuilder.WithTelemetry()` as the new canonical name (matches the `With*` convention adopted by Outbox and Scheduling in their builder migrations — PR #31 in Outbox, PR #27 in Scheduling). Old `UseEventSourcingTelemetry()` retained as `[Obsolete]` shim with `DiagnosticId = "ZAES001"` — non-breaking change.

## Breaking changes
None. Minor release.

## Test plan
- [x] `WithTelemetry()` registers the instrumented event store
- [x] `UseEventSourcingTelemetry()` legacy shim still works (back-compat)
- [x] Full test suite green except 2 pre-existing unrelated SQL flakes (deadletter GUID mismatch, not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)