### PR TITLE
fix(release-please): use per-package CHANGELOG.md path (unblocks 1.0.0 launch)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,47 +8,47 @@
     "src/ZeroAlloc.EventSourcing": {
       "package-name": "ZeroAlloc.EventSourcing",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md"
     },
     "src/ZeroAlloc.EventSourcing.Aggregates": {
       "package-name": "ZeroAlloc.EventSourcing.Aggregates",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.Aggregates.md"
+      "changelog-path": "CHANGELOG.md"
     },
     "src/ZeroAlloc.EventSourcing.Generators": {
       "package-name": "ZeroAlloc.EventSourcing.Generators",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.Generators.md"
+      "changelog-path": "CHANGELOG.md"
     },
     "src/ZeroAlloc.EventSourcing.InMemory": {
       "package-name": "ZeroAlloc.EventSourcing.InMemory",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.InMemory.md"
+      "changelog-path": "CHANGELOG.md"
     },
     "src/ZeroAlloc.EventSourcing.Sql": {
       "package-name": "ZeroAlloc.EventSourcing.Sql",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.Sql.md"
+      "changelog-path": "CHANGELOG.md"
     },
     "src/ZeroAlloc.EventSourcing.SqlServer": {
       "package-name": "ZeroAlloc.EventSourcing.SqlServer",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.SqlServer.md"
+      "changelog-path": "CHANGELOG.md"
     },
     "src/ZeroAlloc.EventSourcing.PostgreSql": {
       "package-name": "ZeroAlloc.EventSourcing.PostgreSql",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.PostgreSql.md"
+      "changelog-path": "CHANGELOG.md"
     },
     "src/ZeroAlloc.EventSourcing.Kafka": {
       "package-name": "ZeroAlloc.EventSourcing.Kafka",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.Kafka.md"
+      "changelog-path": "CHANGELOG.md"
     },
     "src/ZeroAlloc.EventSourcing.Telemetry": {
       "package-name": "ZeroAlloc.EventSourcing.Telemetry",
       "release-type": "simple",
-      "changelog-path": "../../CHANGELOG.Telemetry.md"
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary
After PR #97 (synchronized 1.0.0 trigger) merged, release-please failed with:

```
##[error]release-please failed: illegal pathing characters in path: src/ZeroAlloc.EventSourcing/../../CHANGELOG.md
```

release-please-action 17.3.0 rejects `../../` parent-directory navigation in `changelog-path`. The working pattern (per ZeroAlloc.Specification) is `"CHANGELOG.md"` — each package gets its own CHANGELOG at the package root.

## After merge
release-please re-processes commits on the next push, finds the existing `Release-As: 1.0.0` footers from PR #97 (commit `18179f6`), and opens the 9 release PRs at 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)