### PR TITLE
test(telemetry): disable parallel execution to fix MeterListener cross-talk

### DIFF
--- a/tests/ZeroAlloc.EventSourcing.Telemetry.Tests/AssemblyInfo.cs
+++ b/tests/ZeroAlloc.EventSourcing.Telemetry.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// MeterListener attaches process-wide to any Meter named "ZeroAlloc.EventSourcing".
+// xUnit's default per-class parallelism causes sibling tests to record measurements
+// into each other's listeners, breaking ContainSingle assertions on counters.
+// See InstrumentedAggregateRepositoryTests.SaveAsync_IncrementsCounter_OnSuccess.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Problem

`InstrumentedAggregateRepositoryTests.SaveAsync_IncrementsCounter_OnSuccess` failed in [#131](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/pull/131) with:

```
Expected _counterMeasurements to contain a single item matching
(m.Item1 == "aggregate.saves_total") AndAlso (m.Item2 == 1),
but 3 such items were found.
```

## Root cause

The test fixture sets up a `MeterListener` filtered by `Meter.Name == "ZeroAlloc.EventSourcing"`. xUnit runs tests within a class in parallel by default. Because the listener is **process-wide**, sibling tests (`SaveAsync_StartsActivity_WithCorrectName`, etc.) calling `_sut.SaveAsync(...)` concurrently record their measurements into *every* live listener's `ConcurrentBag`. The bag is concurrent (anticipating parallelism) but the assertion predicate doesn't filter by scope, so cross-test pollution makes `ContainSingle` non-deterministic.

The fact that this test passed on main on 2026-05-04 and failed on 2026-05-06 PR #131 (which only bumps `meziantou.analyzer`) confirms it's a latent flake, not a regression caused by the dep update.

## Fix

Add `[assembly: CollectionBehavior(DisableTestParallelization = true)]` to the `ZeroAlloc.EventSourcing.Telemetry.Tests` project. Tests in this assembly now run serially, eliminating the cross-talk. The other test assemblies are unaffected.

## Alternative considered

Scoping the `MeterListener` per-test (e.g. by an instrument tag containing the test instance ID) would preserve parallelism but requires changes to the production `InstrumentedAggregateRepository` to attach such a tag, and the `_sut` is the only consumer of the meter in the test process. Disabling parallelism is the smaller, more targeted fix.