### PR TITLE
ci: add publish-from-manifest rescue workflow

### DIFF
--- a/.github/workflows/publish-from-manifest.yml
+++ b/.github/workflows/publish-from-manifest.yml
@@ -1,0 +1,60 @@
+name: Publish from manifest
+
+# Manually-triggered rescue workflow that packs and pushes every src/* csproj
+# at the version recorded in .release-please-manifest.json. Designed for the
+# case where release-please created the GitHub release/tag but the publish
+# job missed a sub-package (e.g. a hardcoded pack list went stale or a new
+# sub-package landed without a CI update). --skip-duplicate makes re-runs safe.
+#
+# Walks the release-please manifest — no hardcoded list, survives sub-package
+# additions automatically.
+#
+# Usage: gh workflow run publish-from-manifest.yml --repo ZeroAlloc-Net/<REPO>
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build
+
+      - name: Pack each released package at its manifest version
+        run: |
+          mkdir -p ./nupkg
+          # Walk every path in the release-please manifest and pack at the recorded version.
+          jq -r 'to_entries[] | "\(.key) \(.value)"' .release-please-manifest.json | \
+            while read path version; do
+              for csproj in "$path"/*.csproj; do
+                echo "Packing $csproj at version $version"
+                dotnet pack "$csproj" -c Release --no-build \
+                  -p:PackageVersion="$version" -o ./nupkg
+              done
+            done
+          ls -la ./nupkg
+
+      - name: Push to NuGet
+        run: |
+          dotnet nuget push ./nupkg/*.nupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --skip-duplicate


### PR DESCRIPTION
## Summary

Adds a manually-triggered rescue workflow that re-packs and pushes every package at the version recorded in `.release-please-manifest.json`. Safety net for the partial-publish failure mode where release-please tags + releases succeed but the publish step misses a package.

`ZeroAlloc.Mediator` recently hit this exact failure mode — a new sub-package (`Mediator.Authorization`) landed on GitHub releases but never reached NuGet because the publish job's hardcoded pack list was stale. See [ZeroAlloc-Net/ZeroAlloc.Mediator#76](https://github.com/ZeroAlloc-Net/ZeroAlloc.Mediator/pull/76) for the full pattern.

This PR adds the same defensive workflow here — no functional change today, just insurance.

## Why now

This audit covered every multi-package repo in the org. `Mediator`, `Saga`, and `Specification` already have this workflow; the rest don't. Adding it everywhere makes the partial-publish recovery story uniform.

## How to use (after merge)

```bash
gh workflow run publish-from-manifest.yml --repo ZeroAlloc-Net/<REPO>
```

Watches the manifest, packs every `src/*/*.csproj` (or every manifest path for multi-component repos), pushes to NuGet with `--skip-duplicate`. Safe to run any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
