### PR TITLE
fix(readme): absolute GitHub URLs so nuget.org links resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ await consumer.ConsumeAsync(async (envelope, ct) => {
 });
 ```
 
-See [Stream Consumers Documentation](docs/core-concepts/consumers.md) for complete guide.
+See [Stream Consumers Documentation](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/blob/main/docs/core-concepts/consumers.md) for complete guide.
 
 ## Kafka Integration
 
@@ -110,7 +110,7 @@ await consumer.ConsumeAsync(async (envelope, ct) => {
 });
 ```
 
-See [Kafka Consumer Documentation](docs/core-concepts/kafka-consumer.md) for complete guide.
+See [Kafka Consumer Documentation](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/blob/main/docs/core-concepts/kafka-consumer.md) for complete guide.
 
 ## Projections
 
@@ -164,18 +164,18 @@ The decorator emits, under the `ZeroAlloc.EventSourcing` activity-source/meter n
 
 Any OpenTelemetry SDK wired to the process picks up all three instruments automatically.
 
-> **Breaking change in v2.0:** `WithTelemetry()` now decorates `IAggregateRepository<,>` instead of `IEventStore`. The old `event_store.append` / `event_store.read` / `event_store.subscribe` spans no longer exist; the deleted `InstrumentedEventStore` and its `[Instrument]` attribute on `IEventStore` are gone. Existing dashboards must be re-pointed at `aggregate.load` / `aggregate.save`. See [docs/telemetry.md](docs/telemetry.md) for the full migration table. The legacy `UseEventSourcingTelemetry()` extension remains as `[Obsolete]` and now delegates to `WithTelemetry()`.
+> **Breaking change in v2.0:** `WithTelemetry()` now decorates `IAggregateRepository<,>` instead of `IEventStore`. The old `event_store.append` / `event_store.read` / `event_store.subscribe` spans no longer exist; the deleted `InstrumentedEventStore` and its `[Instrument]` attribute on `IEventStore` are gone. Existing dashboards must be re-pointed at `aggregate.load` / `aggregate.save`. See [docs/telemetry.md](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/blob/main/docs/telemetry.md) for the full migration table. The legacy `UseEventSourcingTelemetry()` extension remains as `[Obsolete]` and now delegates to `WithTelemetry()`.
 
 ## Documentation
 
-Complete documentation available at [/docs](docs/):
+Complete documentation available at [/docs](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/tree/main/docs/):
 
-- [Getting Started](docs/getting-started/)
-- [Core Concepts](docs/core-concepts/)
-- [Usage Guides](docs/usage-guides/)
-- [Testing Strategies](docs/testing/)
-- [Performance & Benchmarks](docs/performance/)
-- [Advanced Topics](docs/advanced/)
+- [Getting Started](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/tree/main/docs/getting-started/)
+- [Core Concepts](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/tree/main/docs/core-concepts/)
+- [Usage Guides](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/tree/main/docs/usage-guides/)
+- [Testing Strategies](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/tree/main/docs/testing/)
+- [Performance & Benchmarks](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/tree/main/docs/performance/)
+- [Advanced Topics](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/tree/main/docs/advanced/)
 
 ## Development
 
@@ -203,4 +203,4 @@ See LICENSE file for details.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/blob/main/CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary

Rewrite all relative links in `README.md` to absolute GitHub URLs. The README ships to nuget.org via `<PackageReadmeFile>`; nuget.org renders it in its own host context, so any `[text](docs/foo.md)` style links 404 on the package page today.

## Pattern

- File links: `[text](path)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/blob/main/path)`
- Directory links: `[text](path/)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/tree/main/path/)`
- Image links: `![alt](img.png)` -> `![alt](https://raw.githubusercontent.com/ZeroAlloc-Net/<repo>/main/img.png)` (raw host so the image renders inline)
- Anchors (`#section`) and already-absolute URLs (`https://...`) unchanged
- `#anchor` fragments preserved on rewritten file links

## Verification

`README.md` still renders cleanly on the GitHub repo page (absolute self-references work in GitHub's renderer too). Once merged, the next NuGet release publishes the updated README and nuget.org links will resolve to the actual files.

Generated with [Claude Code](https://claude.com/claude-code)
