### PR TITLE
fix(ci): widen SDK rollForward + fix latent CS8629 in nullable test assertions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.203",
-    "rollForward": "latestPatch"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   }
 }

--- a/tests/ZeroAlloc.EventSourcing.Tests/CheckpointStoreContractTests.cs
+++ b/tests/ZeroAlloc.EventSourcing.Tests/CheckpointStoreContractTests.cs
@@ -44,7 +44,8 @@ public abstract class CheckpointStoreContractTests
         await store.WriteAsync(consumerId, new StreamPosition(20));
         var result = await store.ReadAsync(consumerId);
 
-        result.Value.Value.Should().Be(20);
+        result.Should().NotBeNull();
+        result!.Value.Value.Should().Be(20);
     }
 
     [Fact]
@@ -79,7 +80,9 @@ public abstract class CheckpointStoreContractTests
         var posA = await store.ReadAsync("consumer-a");
         var posB = await store.ReadAsync("consumer-b");
 
-        posA.Value.Value.Should().Be(10);
-        posB.Value.Value.Should().Be(20);
+        posA.Should().NotBeNull();
+        posB.Should().NotBeNull();
+        posA!.Value.Value.Should().Be(10);
+        posB!.Value.Value.Should().Be(20);
     }
 }


### PR DESCRIPTION
## Problem

CI restore broke on all PRs targeting EventSourcing this morning with:

```
Requested SDK version: 10.0.203
A compatible .NET SDK was not found.
Installed SDKs: 10.0.105, 10.0.201, 10.0.300
```

The runner image rotated overnight and Microsoft retired SDK 10.0.203. The `global.json` had `rollForward: latestPatch` which can't cross feature bands, so 10.0.203 → no resolvable SDK.

## What this PR does

1. **`global.json`**: switches to `version: 10.0.100` + `rollForward: latestFeature` so any 10.0.x SDK satisfies it (no more pin-rot when Microsoft retires patch bands).
2. **`CheckpointStoreContractTests.cs`**: fixes 3 CS8629 nullable warnings that were latent on 10.0.203 but enforced on 10.0.300. The test was unwrapping `StreamPosition?` directly (`result.Value.Value`) without first asserting non-null. Replaced with `result.Should().NotBeNull(); result!.Value.Value.Should()...`.

## Why both fixes together

The SDK widening alone exposes the nullable errors; the nullable fix alone doesn't help while restore is broken. They need to land together to bring main green.

## Blast radius

- Affects only CI configuration + a test file. No production code touched.
- `latestFeature` is broader than `latestPatch` but still scopes within the same major (10.x.x). Stricter than `latestMajor`.
