### PR TITLE
feat(bench): add hand-rolled SQLite event store overhead comparison

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Npgsql"                             Version="10.0.2" />
     <PackageVersion Include="NSubstitute"                        Version="5.3.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient"           Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite"              Version="10.0.7" />
     <PackageVersion Include="Testcontainers.PostgreSql"          Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MsSql"               Version="4.11.0" />
     <PackageVersion Include="BenchmarkDotNet"                    Version="0.15.8" />

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ foreach (var evt in envelope.Events)
 
 All packages follow zero-allocation principles and are optimized for high-throughput scenarios.
 
+## Performance
+
+Correctness-matched overhead vs a hand-rolled SQLite event store (same connection, both transactional, both check stream version inside the transaction). .NET 8.0.26, i9-12900HK, BenchmarkDotNet v0.15.8.
+
+| Operation | Hand-rolled | ZA.EventSourcing | Overhead |
+|---|---:|---:|---:|
+| Append 1 event (transactional, OCC check) | 80.7 µs / 3.80 KB | **106.3 µs / 4.79 KB** | +33% time, +26% alloc |
+| Read 100-event stream (ordered) | 66.0 µs / 11.95 KB | **140.9 µs / 25.23 KB** | +114% time, +111% alloc |
+
+The delta is the cost of the `IEventStore` + `IEventStoreAdapter` + `IEventSerializer` + `IEventTypeRegistry` layer — what you get for it is typed events, pluggable serialization, optimistic concurrency through `StreamPosition`, and composability with `Aggregate<T>`, projections, snapshots, upcasters, and dead-letter handling. At real-database latency the abstraction tax becomes negligible vs the SQL round-trip.
+
+Full methodology: [docs/performance.md](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/blob/main/docs/performance.md).
+
 ## Stream Consumers
 
 ZeroAlloc.EventSourcing includes production-grade stream consumers for reliable event consumption with automatic position tracking, retry logic, and configurable error handling.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -43,6 +43,32 @@ Benchmarks for applying events to projections (read models).
 | ApplyMultipleEventsSequential | — | — | — | — |
 | ApplyTypedDispatch | — | — | — | — |
 
+## Head-to-head vs hand-rolled SQLite event store
+
+<!-- BENCH:START -->
+_Last refreshed: 2026-05-14_
+
+Correctness-matched comparison: both rows use the **same SQLite-in-memory connection** (different tables), both check the current stream version inside a transaction before INSERT, both run an ordered SELECT across the stream on read. Storage variance cancels out — the remaining delta is the cost of the `IEventStore` + `IEventStoreAdapter` + `IEventSerializer` + `IEventTypeRegistry` abstraction layer.
+
+To isolate the abstraction overhead from real-world serialization cost (which both sides would pay equally in production), the ZA row uses a cached no-op serializer. The hand-rolled row similarly stores raw bytes without round-tripping JSON.
+
+.NET 8.0.26, i9-12900HK, BenchmarkDotNet v0.15.8.
+
+| Operation | Hand-rolled | ZA.EventSourcing | Overhead |
+|---|---:|---:|---:|
+| Append (1 event, transactional, OCC check) | 80.7 µs / 3.80 KB | **106.3 µs / 4.79 KB** | +33% time, +26% alloc |
+| Read 100-event stream (ordered) | 66.0 µs / 11.95 KB | **140.9 µs / 25.23 KB** | +114% time, +111% alloc |
+
+**Honest reading**: ZA.EventSourcing adds **a measurable abstraction tax** over a raw SQLite event store — about 33% time on append and ~2× on read. That tax buys you:
+
+- Typed events through `IEventStore.AppendAsync<TEvent>` / `ReadAsync` (the hand-rolled version stores raw bytes the caller has to ser/deser themselves)
+- Pluggable serialization through `IEventSerializer` (so you can swap System.Text.Json for MessagePack, protobuf, or your own zero-alloc serializer without touching the store)
+- Optimistic concurrency through a typed `StreamPosition` API
+- Composability with the rest of the ecosystem (`Aggregate<T>`, projections, snapshots, upcasters, dead-letter handling)
+
+In production the dominant cost on both sides is the serializer + the SQL round-trip — at the millisecond scale of a real database both rows converge and this delta becomes invisible.
+<!-- BENCH:END -->
+
 ## Zero-Allocation Compliance
 
 All core operations target **zero allocations** in steady state. Any allocations shown above represent transient state during benchmark execution and are acceptable for this zero-allocation library.

--- a/src/ZeroAlloc.EventSourcing.Benchmarks/HandRolledOverheadBenchmark.cs
+++ b/src/ZeroAlloc.EventSourcing.Benchmarks/HandRolledOverheadBenchmark.cs
@@ -1,0 +1,151 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data.Sqlite;
+
+namespace ZeroAlloc.EventSourcing.Benchmarks;
+
+// A no-op serializer that returns a pre-cached byte array on Serialize and a
+// pre-cached object on Deserialize. Used by HandRolledOverheadBenchmark so the
+// measured delta isolates the ZA.EventSourcing abstraction overhead from the
+// dominating cost of real-world JSON serialization (which both sides would pay
+// equally in production). Matches the FakeSerializer pattern used by the
+// ZA.Outbox benchmark.
+internal sealed class CachedSerializer : IEventSerializer
+{
+    private static readonly byte[] s_payload = new byte[32];
+    private static readonly BenchmarkEvent s_event = new("cached", s_payload);
+
+    public ReadOnlyMemory<byte> Serialize<TEvent>(TEvent @event) where TEvent : notnull => s_payload;
+    public object Deserialize(ReadOnlyMemory<byte> payload, Type eventType) => s_event;
+}
+
+// Measures the overhead ZA.EventSourcing adds on top of a correctness-matched
+// hand-rolled SQLite event store: per-append optimistic-concurrency check inside
+// a transaction, ordered read across a stream. Both rows use the same SQLite
+// in-memory connection (different tables) so storage variance cancels out — the
+// delta is the cost of the IEventStore + IEventStoreAdapter + IEventSerializer
+// + IEventTypeRegistry abstraction layer.
+
+/// <summary>Benchmarks ZA.EventSourcing overhead vs a correctness-matched hand-rolled SQLite event store.</summary>
+[MemoryDiagnoser]
+[SimpleJob]
+public class HandRolledOverheadBenchmark
+{
+    private const int StreamLength = 100;
+
+    private SqliteConnection _conn = null!;
+    private HandRolledSqliteEventStore _hand = null!;
+    private SqliteEventStoreAdapter _zaAdapter = null!;
+    private EventStore _zaStore = null!;
+
+    private readonly BenchmarkEvent _appendEvent = new("evt-x", new byte[32]);
+    private readonly byte[] _handPayload = new byte[32];
+    private readonly StreamId _readStream = new("read-stream");
+    private long _appendVersion;
+    private long _appendVersionZa;
+
+    /// <summary>Opens the shared SQLite-in-memory connection and pre-populates the read-stream rows.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _conn = new SqliteConnection("Data Source=:memory:");
+        _conn.Open();
+
+        _hand = new HandRolledSqliteEventStore(_conn);
+        _zaAdapter = new SqliteEventStoreAdapter(_conn);
+        var registry = new BenchmarkTypeRegistry();
+        var serializer = new CachedSerializer();
+        _zaStore = new EventStore(_zaAdapter, serializer, registry);
+
+        // Pre-populate the read-streams with 100 events each. The payload is the
+        // same fixed byte array used by the cached serializer so both sides see
+        // identical storage cost.
+        var payload = new byte[32];
+        for (var i = 0; i < StreamLength; i++)
+        {
+            _hand.Append("read-stream", i, nameof(BenchmarkEvent), payload);
+        }
+        for (var i = 0; i < StreamLength; i++)
+        {
+            using var cmd = _conn.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO za_events (stream_id, position, event_type, payload, event_id, occurred_at)
+                VALUES ('read-stream', $pos, 'BenchmarkEvent', $payload, $eid, $occurred);
+                """;
+            cmd.Parameters.AddWithValue("$pos", i + 1);
+            cmd.Parameters.AddWithValue("$payload", payload);
+            cmd.Parameters.AddWithValue("$eid", Guid.NewGuid().ToByteArray());
+            cmd.Parameters.AddWithValue("$occurred", DateTimeOffset.UtcNow.ToString("O"));
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    /// <summary>Disposes the shared SQLite connection.</summary>
+    [GlobalCleanup]
+    public void Cleanup() => _conn.Dispose();
+
+    // --- Append (single event) ---
+    //
+    // Each iteration appends one event to a per-row append stream — we reset
+    // version counters and clear the append rows between iterations so each
+    // run starts from a known state.
+
+    /// <summary>Resets the append-stream rows and version counters before each append iteration.</summary>
+    [IterationSetup(Targets = [nameof(Hand_Append), nameof(Za_Append)])]
+    public void PrepareAppend()
+    {
+        _appendVersion = 0;
+        _appendVersionZa = 0;
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = """
+            DELETE FROM hand_events WHERE stream_id = 'append-stream';
+            DELETE FROM za_events WHERE stream_id = 'append-stream';
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    /// <summary>Hand-rolled baseline: append one event via raw SQLite.</summary>
+    [Benchmark(Baseline = true, Description = "Hand-rolled: append 1 event")]
+    [BenchmarkCategory("Append1")]
+    public long Hand_Append()
+    {
+        _appendVersion = _hand.Append("append-stream", _appendVersion, nameof(BenchmarkEvent), _handPayload);
+        return _appendVersion;
+    }
+
+    /// <summary>ZA.EventSourcing: append one event through the full IEventStore + adapter + serializer pipeline.</summary>
+    [Benchmark(Description = "ZA.EventSourcing: append 1 event")]
+    [BenchmarkCategory("Append1")]
+    public async ValueTask<long> Za_Append()
+    {
+        var result = await _zaStore.AppendAsync(
+            new StreamId("append-stream"),
+            new object[] { _appendEvent }.AsMemory(),
+            new StreamPosition(_appendVersionZa),
+            CancellationToken.None);
+        if (!result.IsSuccess)
+            throw new InvalidOperationException("append failed: " + result.Error);
+        _appendVersionZa = result.Value.NextExpectedVersion.Value;
+        return _appendVersionZa;
+    }
+
+    // --- Read (100-event stream) ---
+    //
+    // No per-iteration reset needed — read is idempotent and the stream is
+    // pre-populated in GlobalSetup.
+
+    /// <summary>Hand-rolled baseline: read a 100-event stream via raw SQLite.</summary>
+    [Benchmark(Description = "Hand-rolled: read 100-event stream")]
+    [BenchmarkCategory("Read100")]
+    public int Hand_Read() => _hand.ReadAll("read-stream", static (_, _, _) => { });
+
+    /// <summary>ZA.EventSourcing: read a 100-event stream through the full IEventStore + adapter + serializer pipeline.</summary>
+    [Benchmark(Description = "ZA.EventSourcing: read 100-event stream")]
+    [BenchmarkCategory("Read100")]
+    public async ValueTask<int> Za_Read()
+    {
+        var count = 0;
+        await foreach (var _ in _zaStore.ReadAsync(_readStream, StreamPosition.Start, CancellationToken.None))
+            count++;
+        return count;
+    }
+}

--- a/src/ZeroAlloc.EventSourcing.Benchmarks/HandRolledSqliteEventStore.cs
+++ b/src/ZeroAlloc.EventSourcing.Benchmarks/HandRolledSqliteEventStore.cs
@@ -1,0 +1,78 @@
+using Microsoft.Data.Sqlite;
+
+namespace ZeroAlloc.EventSourcing.Benchmarks;
+
+// Correctness-matched hand-rolled event store. Same SQLite connection as the ZA
+// SqliteEventStoreAdapter in the benchmark. Same guarantees:
+//   - Append checks current stream version inside a transaction (optimistic concurrency)
+//   - Append INSERTs all events inside the same transaction
+//   - Read returns events ordered by position
+//
+// Differences from the ZA path: no IEventStoreAdapter abstraction, no IEventStore
+// wrapper, no IEventSerializer indirection, no IEventTypeRegistry. Caller hands
+// the raw byte payload + event type tag straight in.
+internal sealed class HandRolledSqliteEventStore
+{
+    private readonly SqliteConnection _conn;
+
+    public HandRolledSqliteEventStore(SqliteConnection conn)
+    {
+        _conn = conn;
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS hand_events (
+              stream_id TEXT NOT NULL,
+              position INTEGER NOT NULL,
+              event_type TEXT NOT NULL,
+              payload BLOB NOT NULL,
+              PRIMARY KEY (stream_id, position)
+            );
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    // Returns the new stream version on success, -1 on optimistic-concurrency conflict.
+    public long Append(string streamId, long expectedVersion, string eventType, byte[] payload)
+    {
+        using var tx = _conn.BeginTransaction();
+        using (var check = _conn.CreateCommand())
+        {
+            check.Transaction = tx;
+            check.CommandText = "SELECT COALESCE(MAX(position), 0) FROM hand_events WHERE stream_id = $sid;";
+            check.Parameters.AddWithValue("$sid", streamId);
+            var current = (long)(check.ExecuteScalar() ?? 0L);
+            if (current != expectedVersion)
+                return -1;
+        }
+        var newVersion = expectedVersion + 1;
+        using (var ins = _conn.CreateCommand())
+        {
+            ins.Transaction = tx;
+            ins.CommandText = "INSERT INTO hand_events (stream_id, position, event_type, payload) VALUES ($sid, $pos, $type, $payload);";
+            ins.Parameters.AddWithValue("$sid", streamId);
+            ins.Parameters.AddWithValue("$pos", newVersion);
+            ins.Parameters.AddWithValue("$type", eventType);
+            ins.Parameters.AddWithValue("$payload", payload);
+            ins.ExecuteNonQuery();
+        }
+        tx.Commit();
+        return newVersion;
+    }
+
+    // Reads every event from the stream in position order, invoking the handler per event.
+    // Matches the ZA read path: pull rows, hand each one back to the caller.
+    public int ReadAll(string streamId, Action<long, string, byte[]> handler)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT position, event_type, payload FROM hand_events WHERE stream_id = $sid ORDER BY position;";
+        cmd.Parameters.AddWithValue("$sid", streamId);
+        using var r = cmd.ExecuteReader();
+        var count = 0;
+        while (r.Read())
+        {
+            handler(r.GetInt64(0), r.GetString(1), (byte[])r.GetValue(2));
+            count++;
+        }
+        return count;
+    }
+}

--- a/src/ZeroAlloc.EventSourcing.Benchmarks/SqliteEventStoreAdapter.cs
+++ b/src/ZeroAlloc.EventSourcing.Benchmarks/SqliteEventStoreAdapter.cs
@@ -1,0 +1,113 @@
+using Microsoft.Data.Sqlite;
+using ZeroAlloc.Results;
+
+namespace ZeroAlloc.EventSourcing.Benchmarks;
+
+// IEventStoreAdapter that talks directly to SQLite via Microsoft.Data.Sqlite.
+// Used only by HandRolledOverheadBenchmark — the ZA row runs against THIS adapter
+// while the HandRolledSqliteEventStore row uses a parallel SQLite table via raw SQL
+// against the SAME connection. Storage variance cancels out of the delta, so the
+// remaining number is the ZA abstraction cost on top of the same INSERT/SELECT.
+internal sealed class SqliteEventStoreAdapter : IEventStoreAdapter
+{
+    private readonly SqliteConnection _conn;
+
+    public SqliteEventStoreAdapter(SqliteConnection conn)
+    {
+        _conn = conn;
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS za_events (
+              stream_id TEXT NOT NULL,
+              position INTEGER NOT NULL,
+              event_type TEXT NOT NULL,
+              payload BLOB NOT NULL,
+              event_id BLOB NOT NULL,
+              occurred_at TEXT NOT NULL,
+              PRIMARY KEY (stream_id, position)
+            );
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    public ValueTask<Result<AppendResult, StoreError>> AppendAsync(
+        StreamId id,
+        ReadOnlyMemory<RawEvent> events,
+        StreamPosition expectedVersion,
+        CancellationToken ct = default)
+    {
+        using var tx = _conn.BeginTransaction();
+        using var check = _conn.CreateCommand();
+        check.Transaction = tx;
+        check.CommandText = "SELECT COALESCE(MAX(position), 0) FROM za_events WHERE stream_id = $sid;";
+        check.Parameters.AddWithValue("$sid", id.Value);
+        var current = (long)(check.ExecuteScalar() ?? 0L);
+
+        if (current != expectedVersion.Value)
+        {
+            return ValueTask.FromResult(Result<AppendResult, StoreError>.Failure(
+                StoreError.Conflict(id, expectedVersion, new StreamPosition(current))));
+        }
+
+        var span = events.Span;
+        for (var i = 0; i < span.Length; i++)
+        {
+            var e = span[i];
+            using var cmd = _conn.CreateCommand();
+            cmd.Transaction = tx;
+            cmd.CommandText = """
+                INSERT INTO za_events (stream_id, position, event_type, payload, event_id, occurred_at)
+                VALUES ($sid, $pos, $type, $payload, $eid, $occurred);
+                """;
+            cmd.Parameters.AddWithValue("$sid", id.Value);
+            cmd.Parameters.AddWithValue("$pos", e.Position.Value);
+            cmd.Parameters.AddWithValue("$type", e.EventType);
+            cmd.Parameters.AddWithValue("$payload", e.Payload.ToArray());
+            cmd.Parameters.AddWithValue("$eid", e.Metadata.EventId.ToByteArray());
+            cmd.Parameters.AddWithValue("$occurred", e.Metadata.OccurredAt.ToString("O"));
+            cmd.ExecuteNonQuery();
+        }
+        tx.Commit();
+
+        return ValueTask.FromResult(Result<AppendResult, StoreError>.Success(
+            new AppendResult(id, new StreamPosition(expectedVersion.Value + span.Length))));
+    }
+
+    public async IAsyncEnumerable<RawEvent> ReadAsync(
+        StreamId id,
+        StreamPosition from,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT position, event_type, payload, event_id, occurred_at
+            FROM za_events
+            WHERE stream_id = $sid AND position > $from
+            ORDER BY position;
+            """;
+        cmd.Parameters.AddWithValue("$sid", id.Value);
+        cmd.Parameters.AddWithValue("$from", from.Value);
+        using var r = cmd.ExecuteReader();
+        while (r.Read())
+        {
+            var pos = r.GetInt64(0);
+            var type = r.GetString(1);
+            var payload = (byte[])r.GetValue(2);
+            var eventIdBytes = (byte[])r.GetValue(3);
+            var occurred = DateTimeOffset.Parse(r.GetString(4), System.Globalization.CultureInfo.InvariantCulture);
+            yield return new RawEvent(
+                new StreamPosition(pos),
+                type,
+                payload,
+                new EventMetadata(new Guid(eventIdBytes), type, occurred, null, null));
+        }
+        await ValueTask.CompletedTask.ConfigureAwait(false);
+    }
+
+    public ValueTask<IEventSubscription> SubscribeAsync(
+        StreamId id,
+        StreamPosition from,
+        Func<RawEvent, CancellationToken, ValueTask> handler,
+        CancellationToken ct = default)
+        => throw new NotSupportedException("Subscriptions not exercised by this benchmark.");
+}

--- a/src/ZeroAlloc.EventSourcing.Benchmarks/ZeroAlloc.EventSourcing.Benchmarks.csproj
+++ b/src/ZeroAlloc.EventSourcing.Benchmarks/ZeroAlloc.EventSourcing.Benchmarks.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ZeroAlloc.Serialisation" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Adds a correctness-matched comparison between ZA.EventSourcing and a raw-SQL event store backed by the **same** SQLite-in-memory connection (different tables), so storage variance cancels out of the delta.
- Both rows check current stream version inside a transaction before INSERT and run an ordered SELECT across the stream on read; the ZA side uses a no-op cached serializer to isolate abstraction overhead from real-world JSON cost (which both sides would pay equally in production).
- README + docs/performance.md get a Performance section with the numbers; the doc has \`BENCH:START\`/\`BENCH:END\` sentinels so the ZA.Templates aggregator can scrape it.

Numbers, net8.0, i9-12900HK, BDN v0.15.8:

| Operation | Hand-rolled | ZA.EventSourcing | Overhead |
|---|---:|---:|---:|
| Append 1 event (transactional, OCC check) | 80.7 µs / 3.80 KB | 106.3 µs / 4.79 KB | +33% time, +26% alloc |
| Read 100-event stream (ordered) | 66.0 µs / 11.95 KB | 140.9 µs / 25.23 KB | +114% time, +111% alloc |

Framing: the delta is the cost of \`IEventStore\` + \`IEventStoreAdapter\` + \`IEventSerializer\` + \`IEventTypeRegistry\`. What that buys: typed events, pluggable serialization, optimistic concurrency through \`StreamPosition\`, and composability with \`Aggregate<T>\`, projections, snapshots, upcasters, and dead-letter handling. At real-database latency the abstraction tax becomes invisible vs the SQL round-trip.

## Test plan

- [x] \`dotnet build src/ZeroAlloc.EventSourcing.Benchmarks -c Release\` clean
- [x] \`dotnet src/ZeroAlloc.EventSourcing.Benchmarks/bin/Release/net8.0/ZeroAlloc.EventSourcing.Benchmarks.dll --filter "*HandRolledOverheadBenchmark*"\` — 4 rows, both Append and Read pairs
- [ ] CI green